### PR TITLE
Add battle assist, protect second wave when only rogues in army

### DIFF
--- a/js/inject.js
+++ b/js/inject.js
@@ -178,6 +178,7 @@
 				'settings',
 				'investment',
 				'strategy-points',
+				'battle-assist',
 				'citymap',
 				'hidden-rewards'
 			];

--- a/js/web/_helper/js/_helper.js
+++ b/js/web/_helper/js/_helper.js
@@ -35,7 +35,7 @@ if( typeof helper == 'undefined' ) {
 helper.str = {
 	/**
 	 * Function to copy string to clipboard
-	 * 
+	 *
 	 * <a href="/param">@param</a> {string} [textToCopy] Source string
 	 */
 	copyToClipboard: function(textToCopy){
@@ -148,13 +148,13 @@ let HTML = {
 			cords = localStorage.getItem(args['id'] + 'Cords');
 
 		// Minimierenbutton
-		if(args['minimize'] !== undefined){
+		if(args['minimize']){
 			let min = $('<span />').addClass('window-minimize');
 			min.insertAfter(title);
 		}
 
 		// Lautsprecher für Töne
-		if(args['speaker'] !== undefined){
+		if(args['speaker']){
 
 			// Click Event grillen...
 			$('body').off('click', '#' + args['speaker']);
@@ -166,19 +166,19 @@ let HTML = {
 		}
 
 		// es gibt gespeicherte Koordinaten
-		if(cords !== null){
+		if(cords){
 			let c = cords.split('|');
 			div.offset({ top: Math.min(c[0], window.innerHeight - 50), left: Math.min(c[1], window.innerWidth - 100) });  // Verhindere, dass Fenster außerhalb plaziert werden
 		}
 
 		// Ein Link zu einer Seite
-		if(args['ask'] !== undefined){
+		if(args['ask']){
 			div.find(title).after( $('<span />').addClass('window-ask').attr('data-url', args['ask']) );
 		}
 
 		// wenn Box im DOM, verfeinern
 		$('body').append(div).promise().done(function() {
-			if(args['auto_close'] !== undefined){
+			if(args['auto_close']){
 				$('body').on('click', '#' + args['id'] + 'close', function(){
 					$('#' + args['id']).fadeToggle('fast', function(){
 						$(this).remove();
@@ -186,25 +186,25 @@ let HTML = {
 				});
 			}
 
-			if(args['ask'] !== undefined) {
+			if(args['ask']) {
 				$('body').on('click', '.window-ask', function() {
 					window.open( $(this).data('url'), '_blank');
 				});
 			}
 
-			if(args['dragdrop'] !== undefined) {
+			if(args['dragdrop']) {
 				HTML.DragBox(document.getElementById(args['id']), args['saveCords']);
 			}
 
-			if(args['resize'] !== undefined){
+			if(args['resize']) {
 				HTML.Resizeable(args['id']);
 			}
 
-			if(args['minimize'] !== undefined){
+			if(args['minimize']) {
 				HTML.MinimizeBox(div);
 			}
 
-			if(args['speaker'] !== undefined){
+			if(args['speaker']) {
 				$('#' + args['speaker']).addClass( localStorage.getItem(args['speaker']) );
 			}
 

--- a/js/web/_i18n/en.json
+++ b/js/web/_i18n/en.json
@@ -8,7 +8,7 @@
 		"API.UpdateSuccess": "Update performed",
 		"Boxes.Api.Title": "Extension API Settings",
 		"Boxes.BattleAssist.Title": "Stop!",
-		"Boxes.BattleAssist.Text": "Your army have only rogues, please recover units using diamonds or retreat!",
+		"Boxes.BattleAssist.Text": "Your army have only rogues. Please, recover units using diamonds or retreat!",
 		"Boxes.Calculator.ActiveRecurringQuest": "Active recurring quest:",
 		"Boxes.Calculator.ArkBonus": "Arc bonus",
 		"Boxes.Calculator.AvailableFP": "Available Forgepoints",

--- a/js/web/_i18n/en.json
+++ b/js/web/_i18n/en.json
@@ -7,6 +7,8 @@
 		"API.LGInvest": "Your great building investments have been transferred",
 		"API.UpdateSuccess": "Update performed",
 		"Boxes.Api.Title": "Extension API Settings",
+		"Boxes.BattleAssist.Title": "Stop!",
+		"Boxes.BattleAssist.Text": "Your army have only rogues, please recover units using diamonds or retreat!",
 		"Boxes.Calculator.ActiveRecurringQuest": "Active recurring quest:",
 		"Boxes.Calculator.ArkBonus": "Arc bonus",
 		"Boxes.Calculator.AvailableFP": "Available Forgepoints",

--- a/js/web/_i18n/en.json
+++ b/js/web/_i18n/en.json
@@ -8,7 +8,7 @@
 		"API.UpdateSuccess": "Update performed",
 		"Boxes.Api.Title": "Extension API Settings",
 		"Boxes.BattleAssist.Title": "Stop!",
-		"Boxes.BattleAssist.Text": "Your army have only rogues. Please, recover units using diamonds or retreat!",
+		"Boxes.BattleAssist.Text": "Your army has only Rogues. Either heal units using diamonds or retreat!",
 		"Boxes.Calculator.ActiveRecurringQuest": "Active recurring quest:",
 		"Boxes.Calculator.ArkBonus": "Arc bonus",
 		"Boxes.Calculator.AvailableFP": "Available Forgepoints",

--- a/js/web/battle-assist/css/battle-assist.css
+++ b/js/web/battle-assist/css/battle-assist.css
@@ -1,0 +1,27 @@
+#battleAssistStopDialog {
+    top: calc(50vh + 230px);
+    left: calc(50vw - 92px);
+}
+
+#battleAssistStopDialogBody {
+    width: 360px;
+    height: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    font-size: 120%;
+    background: #800;
+}
+
+#battleAssistStopDialogBody .blink {
+    animation: battleAssistBlink 1s linear infinite;
+}
+
+@keyframes battleAssistBlink {
+    0%{     color: #ff0;    }
+    49%{    color: #ff0; }
+    60%{    color: transparent; }
+    99%{    color:transparent;  }
+    100%{   color: #ff0;    }
+}

--- a/js/web/battle-assist/js/battle-assist.js
+++ b/js/web/battle-assist/js/battle-assist.js
@@ -1,8 +1,6 @@
 FoEproxy.addHandler('BattlefieldService', 'all', (data, postData) => {
     HTML.CloseOpenBox('battleAssistStopDialog');
 
-    const isAutoBattle = data.responseData.isAutoBattle; // isAutoBattle is part of BattleRealm only
-    //
     const state = data.responseData.__class__ === 'BattleRealm' ? data.responseData.state : data.responseData;
     if (state.__class__ !== 'BattleRealmState') {
         return;

--- a/js/web/battle-assist/js/battle-assist.js
+++ b/js/web/battle-assist/js/battle-assist.js
@@ -1,0 +1,40 @@
+FoEproxy.addHandler('BattlefieldService', 'all', (data, postData) => {
+    HTML.CloseOpenBox('battleAssistStopDialog');
+
+    const isAutoBattle = data.responseData.isAutoBattle; // isAutoBattle is part of BattleRealm only
+    //
+    const state = data.responseData.__class__ === 'BattleRealm' ? data.responseData.state : data.responseData;
+    if (state.__class__ !== 'BattleRealmState') {
+        return;
+    }
+
+    const { winnerBit, unitsOrder, ranking_data } = state;
+    if (winnerBit !== 1) { return; } // 1 - win
+
+    if (!ranking_data.nextArmy) { return }
+
+    const atLeastOneNotRogue = unitsOrder.filter(it => it.teamFlag === 1 && it.currentHitpoints).some(it => it.unitTypeId != 'rogue');
+    const haveAliveUnits = unitsOrder.filter(it => it.teamFlag === 1 && it.currentHitpoints).length;
+    if (haveAliveUnits && !atLeastOneNotRogue) {
+        BattleAssist.ShowStopNextAttackDialog();
+    }
+});
+
+let BattleAssist = {
+    ShowStopNextAttackDialog: () => {
+        HTML.AddCssFile('battle-assist');
+
+        HTML.Box({
+			'id': 'battleAssistStopDialog',
+			'title': i18n('Boxes.BattleAssist.Title'),
+			'auto_close': true,
+			'dragdrop': false,
+			'minimize': false
+		});
+        $('#battleAssistStopDialogBody').html(`
+<div class="blink">
+${i18n('Boxes.BattleAssist.Text')}
+</div>
+`);
+    },
+}

--- a/js/web/campagnemap/js/campagnemap.js
+++ b/js/web/campagnemap/js/campagnemap.js
@@ -45,7 +45,7 @@ let KampagneMap = {
 				'title': i18n('Boxes.Campagne.Title'),
 				'auto_close': true,
 				'dragdrop': true,
-				'minimize': false
+				'minimize': true
 			});
 
 			// CSS in den DOM prügeln

--- a/js/web/eventquest/js/eventquest.js
+++ b/js/web/eventquest/js/eventquest.js
@@ -87,7 +87,7 @@ FoEproxy.addHandler('ChestEventService', 'getOverview', (data, postData) => {
     // Ungültige Daten => Event wird nicht unterstützt => Fenster nicht anzeigen
     if (ChestData.length === 0) {
         return;
-    }   
+    }
 
     EventQuest.Chests = ChestData;
     EventQuest.ShowChests();
@@ -143,7 +143,7 @@ let EventQuest = {
                 HTML.Box({
                     'id': 'event',
                     'title': i18n('Boxes.EventList.Title') + EventQuest.Event['eventname'],
-                    'auto_close': false,
+                    'auto_close': true,
                     'dragdrop': true,
                     'minimize': true
                 });
@@ -166,7 +166,7 @@ let EventQuest = {
                     HTML.Box({
                         'id': 'event',
                         'title': i18n('Boxes.EventList.Title') + EventQuest.Event['eventname'],
-                        'auto_close': false,
+                        'auto_close': true,
                         'dragdrop': true,
                         'minimize': true
                     });
@@ -315,7 +315,7 @@ let EventQuest = {
             HTML.Box({
                 'id': 'eventchests',
                 'title': i18n('Boxes.EventChests.Title'),
-                'auto_close': false,
+                'auto_close': true,
                 'dragdrop': true,
                 'minimize': true
             });
@@ -358,7 +358,7 @@ let EventQuest = {
             '</tr>' +
 
             '</thead>');
-        
+
         let BestMainPrizeCost = 999999,
             BestDailyPrizeCost = 999999;
 
@@ -368,7 +368,7 @@ let EventQuest = {
             BestMainPrizeCost = Math.min(BestMainPrizeCost, EventQuest.Chests[i]['costpermainprizestep']);
             BestDailyPrizeCost = Math.min(BestDailyPrizeCost, EventQuest.Chests[i]['costperdailyprize']);
         }
-        
+
         for (let i in EventQuest.Chests) {
             if (!EventQuest.Chests.hasOwnProperty(i)) continue;
 

--- a/js/web/hidden-rewards/js/hidden-rewards.js
+++ b/js/web/hidden-rewards/js/hidden-rewards.js
@@ -27,7 +27,7 @@ let HiddenRewards = {
             HTML.Box({
                 'id': 'HiddenRewardBox',
                 'title': i18n('Boxes.HiddenRewards.Title'),
-                'auto_close': false,
+                'auto_close': true,
                 'dragdrop': true,
                 'minimize': true
             });

--- a/js/web/investment/js/investment.js
+++ b/js/web/investment/js/investment.js
@@ -32,7 +32,7 @@ let Investment = {
             HTML.Box({
                 'id': 'Investment',
                 'title': i18n('Boxes.Investment.Title'),
-                'auto_close': false,
+                'auto_close': true,
                 'dragdrop': true,
             });
 


### PR DESCRIPTION
Sadly only second (or more) wave can be protected by clicking attack by mistake
![attack](https://user-images.githubusercontent.com/213405/80279274-2b581300-8705-11ea-9978-3a6d6ecc15a3.jpg)
