### PR TITLE
Style: Align read-buildings's attack bonuses

### DIFF
--- a/js/web/read-buildings/js/read-buildings.js
+++ b/js/web/read-buildings/js/read-buildings.js
@@ -194,12 +194,19 @@ let Reader = {
 
 		let div = $('#ResultBox'),
 			h = [];
-
-		h.push(HTML.i18nReplacer(i18n('Boxes.Neighbors.AttackingArmy'), { 'attatt': Reader.ArmyBoosts['AttackAttackBoost'], 'attdef': Reader.ArmyBoosts['AttackDefenseBoost'] }));
-		h.push('<br>');
-		h.push(HTML.i18nReplacer(i18n('Boxes.Neighbors.DefendingArmy'), { 'defatt': Reader.ArmyBoosts['DefenseAttackBoost'], 'defdef': Reader.ArmyBoosts['DefenseDefenseBoost'] }));
-		h.push('<br>');
-
+        const boosts = Reader.ArmyBoosts;
+        h.push(`
+<div style="margin: 3px 5px">
+${HTML.i18nReplacer(i18n('Boxes.Neighbors.AttackingArmy'), {
+   attatt: `<b>${boosts.AttackAttackBoost}</b>`,
+   attdef: `<b>${boosts.AttackDefenseBoost}</b>`
+})}
+<br />
+${HTML.i18nReplacer(i18n('Boxes.Neighbors.DefendingArmy'), {
+    defatt: `<b>${boosts.DefenseAttackBoost}</b>`,
+    defdef: `<b>${boosts.DefenseDefenseBoost}</b>`})}
+</div>
+`)
 		if (rd.length > 0) {
 			h.push('<table class="foe-table" style="margin-bottom: 15px">');
 


### PR DESCRIPTION
Just add padding and bold font for number to the att/def bonuses
![align](https://user-images.githubusercontent.com/213405/80286490-5ad24400-8734-11ea-87f0-0791d2b604e5.jpg)
