### PR TITLE
Prevent sending keys to game if focused input fields of Boxes

### DIFF
--- a/js/web/_helper/js/_helper.js
+++ b/js/web/_helper/js/_helper.js
@@ -209,6 +209,11 @@ let HTML = {
 			}
 
 			div.fadeToggle('fast');
+
+            // Stop propagation of key event out of inputs in this box to FOE
+            $(`#${args.id}`).on('keydown keyup change', (e) => {
+                e.stopPropagation();
+            });
 		});
 	},
 


### PR DESCRIPTION
FOE Helper should not send keyboard keys to game if focused inputs in helper windows.

This fix is applied ONLY to all Helper's window
