### PR TITLE
Fix changing language and menu size change

### DIFF
--- a/js/web/_helper/js/_helper.js
+++ b/js/web/_helper/js/_helper.js
@@ -211,7 +211,7 @@ let HTML = {
 			div.fadeToggle('fast');
 
             // Stop propagation of key event out of inputs in this box to FOE
-            $(`#${args.id}`).on('keydown keyup change', (e) => {
+            $(`#${args.id}`).on('keydown keyup', (e) => {
                 e.stopPropagation();
             });
 		});

--- a/js/web/settings/js/settings.js
+++ b/js/web/settings/js/settings.js
@@ -323,7 +323,7 @@ let Settings = {
 			ip.val(value);
 		}
 
-		$('body').on('keyup', '#menu-input-length', function(){
+		$('#SettingsBox').on('keyup', '#menu-input-length', function(){
 			let value = $(this).val();
 
 			if(value > 0){


### PR DESCRIPTION
Because we now stop propagation event out from Box some llisteners are not working that use $('body')

In next step we SHOULD replace all `$('body').on(` within `$('#SOME_WINDOW_ID).on`.

Please use window id instead of body as selector of parent element