### PR TITLE
Fix error in info box when testing for falsy

### DIFF
--- a/js/web/infoboard/js/infoboard.js
+++ b/js/web/infoboard/js/infoboard.js
@@ -168,7 +168,7 @@ let Infoboard = {
 
         let Msg = data[0];
 
-        if (Msg === undefined || Msg['requestClass'] === undefined) {
+        if (!Msg || !Msg['requestClass']) {
             return;
         }
 
@@ -178,13 +178,13 @@ let Infoboard = {
             s = c + '_' + m + t;
 
         // Gibt es eine Funktion dafür?
-        if (Info[s] === undefined) {
+        if (!Info[s]) {
             return;
         }
 
         let bd = Info[s](Msg['responseData']);
 
-        if (bd === false) {
+        if (!bd) {
             return;
         }
 
@@ -194,7 +194,7 @@ let Infoboard = {
 
 
         // wenn nicht angezeigt werden soll, direkt versteckeln
-        if (status === false) {
+        if (!status) {
             tr.hide();
         }
 
@@ -205,7 +205,7 @@ let Infoboard = {
 
         $('#BackgroundInfoTable tbody').prepend(tr);
 
-        if (Infoboard.PlayInfoSound && status !== false) {
+        if (Infoboard.PlayInfoSound && status) {
             Infoboard.SoundFile.play();
         }
     },


### PR DESCRIPTION
Some times there are errors in infobox, this should fix it
Done use `if (foo=== false)`, but just `if (foo)`.