### PR TITLE
Event fixes and filter plunderer by visited player even if box is not open 

### DIFF
--- a/css/web/boxes.css
+++ b/css/web/boxes.css
@@ -78,6 +78,9 @@
 	font-weight: 700;
 	display: block;
 	font-size: 1rem;
+	overflow: hidden;
+	white-space: pre;
+	text-overflow: ellipsis;
 }
 
 .window-head span:nth-child(2) {

--- a/js/web/_helper/js/_helper.js
+++ b/js/web/_helper/js/_helper.js
@@ -155,10 +155,6 @@ let HTML = {
 
 		// Lautsprecher für Töne
 		if(args['speaker']){
-
-			// Click Event grillen...
-			$('body').off('click', '#' + args['speaker']);
-
 			let spk = $('<span />').addClass('window-speaker').attr('id', args['speaker']);
 			spk.insertAfter(title);
 
@@ -179,7 +175,7 @@ let HTML = {
 		// wenn Box im DOM, verfeinern
 		$('body').append(div).promise().done(function() {
 			if(args['auto_close']){
-				$('body').on('click', '#' + args['id'] + 'close', function(){
+				$(`#${args.id}`).on('click', '#' + args['id'] + 'close', function(){
 					$('#' + args['id']).fadeToggle('fast', function(){
 						$(this).remove();
 					});
@@ -187,7 +183,7 @@ let HTML = {
 			}
 
 			if(args['ask']) {
-				$('body').on('click', '.window-ask', function() {
+				$(`#${args.id}`).on('click', '.window-ask', function() {
 					window.open( $(this).data('url'), '_blank');
 				});
 			}

--- a/js/web/_menu/js/_menu.js
+++ b/js/web/_menu/js/_menu.js
@@ -694,7 +694,6 @@ let _menu = {
 
 		btn_Plunderer.on('click', function () {
       		Plunderer.page = 1;
-      		Plunderer.filterByPlayerId = null;
 			Plunderer.Show();
 		});
 

--- a/js/web/calculator/js/calculator.js
+++ b/js/web/calculator/js/calculator.js
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  * **************************************************************************************
  *
  * Dateiname:                 calculator.js
@@ -38,7 +38,7 @@ let Calculator = {
 	*
 	*/
 	Open: () => {
-		
+
 		// Nur Übersicht verfügbar
 		if (Calculator.Overview !== undefined && Calculator.CityMapEntity === undefined) {
 			Calculator.ShowOverview(false);
@@ -124,7 +124,7 @@ let Calculator = {
 
 		let PlayerID = Calculator.CityMapEntity['player_id'],
             h = [];
-		
+
         // Wenn sich Spieler geändert hat, dann BuildingName/PlayerName zurücksetzen
 		if (Calculator.CityMapEntity['player_id'] !== Calculator.LastPlayerID) {
 			Calculator.PlayerName = undefined;
@@ -156,7 +156,7 @@ let Calculator = {
         // BuildingName konnte nicht aus der BuildingInfo geladen werden
 		let BuildingName = BuildingNamesi18n[Calculator.CityMapEntity['cityentity_id']]['name'];
 		let Level = (Calculator.CityMapEntity['level'] !== undefined ? Calculator.CityMapEntity['level'] : 0);
-        
+
         h.push('<div class="text-center dark-bg" style="padding:5px 0 3px;">');
 
         // LG - Daten + Spielername
@@ -207,7 +207,7 @@ let Calculator = {
         h.push('</div>');
 
         h.push('</div>');
-        
+
         // Tabelle zusammen fummeln
 		h.push('<table style="width:100%"><tbody><tr>');
 		h.push('<td><table id="costTableFordern" class="foe-table"></table></td>');
@@ -217,11 +217,11 @@ let Calculator = {
 
         // Wieviel fehlt noch bis zum leveln?
 		let rest = (Calculator.CityMapEntity['state']['invested_forge_points'] === undefined ? Calculator.CityMapEntity['state']['forge_points_for_level_up'] : Calculator.CityMapEntity['state']['forge_points_for_level_up'] - Calculator.CityMapEntity['state']['invested_forge_points']);
-        
+
 		h.push('<div class="text-center" style="margin-top:5px;margin-bottom:5px;"><em>' + i18n('Boxes.Calculator.Up2LevelUp') + ': <span id="up-to-level-up" style="color:#FFB539">' + HTML.Format(rest) + '</span> ' + i18n('Boxes.Calculator.FP') + '</em></div>');
 
 		h.push(Calculator.GetRecurringQuestsLine());
-		
+
         // in die bereits vorhandene Box drücken
         $('#costCalculator').find('#costCalculatorBody').html(h.join(''));
 
@@ -235,28 +235,28 @@ let Calculator = {
 		else if (Calculator.CityMapEntity['connected'] === undefined) {
             $('#costCalculator').find('#costCalculatorBody').append($('<div />').addClass('lg-not-possible').attr('data-text', i18n('Boxes.Calculator.LGNotConnected')));
         }
- 
+
         Calculator.CalcBody();
-		
+
 		if (!Calculator.MainListenerRegistered) {
 			Calculator.MainListenerRegistered = true;
 
 			// schnell zwischen den Prozenten wechseln
-			$('body').on('click', '.btn-toggle-arc', function () {
+			$('#costCalculator').on('click', '.btn-toggle-arc', function () {
 				Calculator.ForderBonus = parseFloat($(this).data('value'));
 				$('#costFactor').val(Calculator.ForderBonus);
-				localStorage.setItem('CalculatorForderBonus', Calculator.ForderBonus);			
+				localStorage.setItem('CalculatorForderBonus', Calculator.ForderBonus);
 				Calculator.CalcBody();
 			});
-			
+
 			// wenn der Wert des Archebonus verändert wird, Event feuern
-			$('body').on('blur', '#costFactor', function () {
+			$('#costCalculator').on('blur', '#costFactor', function () {
 				Calculator.ForderBonus = parseFloat($('#costFactor').val());
 				localStorage.setItem('CalculatorForderBonus', Calculator.ForderBonus);
 				Calculator.CalcBody();
 	        });
 
-			$('body').on('click', '#CalculatorTone', function () {
+			$('#costCalculator').on('click', '#CalculatorTone', function () {
 
 				let disabled = $(this).hasClass('deactivated');
 
@@ -303,8 +303,8 @@ let Calculator = {
 
 		return h.join();
 	},
-	
-	   
+
+
 	/**
 	 * Der Tabellen-Körper mit allen Funktionen
 	 *
@@ -349,7 +349,7 @@ let Calculator = {
 				CurrentFP,
 				TotalFP,
 				RestFP,
-				IsSelf = false;			
+				IsSelf = false;
 
 			if (Calculator.Rankings[i]['rank'] === undefined || Calculator.Rankings[i]['rank'] === -1) {
 				continue;
@@ -370,7 +370,7 @@ let Calculator = {
 			ForderRankCosts[Rank] = undefined;
 			SnipeRankCosts[Rank] = undefined;
 			Einzahlungen[Rank] = 0;
-				
+
 			if (Calculator.Rankings[i]['reward']['strategy_point_amount'] !== undefined)
 				FPNettoRewards[Rank] = Math.round(Calculator.Rankings[i]['reward']['strategy_point_amount']);
 
@@ -384,7 +384,7 @@ let Calculator = {
 			BPRewards[Rank] = Math.round(BPRewards[Rank] * arc);
 			MedalRewards[Rank] = Math.round(MedalRewards[Rank] * arc);
 			ForderFPRewards[Rank] = Math.round(FPNettoRewards[Rank] * ForderArc);
-			
+
 			if (EigenPos !== undefined && i > EigenPos) {
 				ForderStates[Rank] = 'NotPossible';
 				SnipeStates[Rank] = 'NotPossible';
@@ -463,7 +463,7 @@ let Calculator = {
 
 				if (ExitLoop)
 					continue;
-				
+
 				// Selbe Kosten wie vorheriger Rang => nicht belegbar
 				if (SnipeLastRankCost !== undefined && SnipeRankCosts[Rank] === SnipeLastRankCost) {
 					ForderStates[Rank] = 'NotPossible';
@@ -537,11 +537,11 @@ let Calculator = {
 				EinsatzClass = (ForderFPRewards[Rank] > StrategyPoints.AvailableFP ? 'error' : ''), //Default: rot wenn Vorrat nicht ausreichend, sonst gelb
 				EinsatzText = HTML.Format(ForderFPRewards[Rank]) + Calculator.FormatForderRankDiff(ForderRankDiff), //Default: Einsatz + ForderRankDiff
 				EinsatzTooltip = [HTML.i18nReplacer(i18n('Boxes.Calculator.TTForderCosts'), { 'nettoreward': FPNettoRewards[Rank], 'forderfactor': (100 + Calculator.ForderBonus), 'costs': ForderFPRewards[Rank] })],
-				
+
 				GewinnClass = (ForderGewinn >= 0 ? 'success' : 'error'), //Default: Grün wenn >= 0 sonst rot
 				GewinnText = HTML.Format(ForderGewinn), //Default: Gewinn
 				GewinnTooltip,
-				
+
 				KursClass,
 				KursText,
 				KursTooltip = [];
@@ -561,7 +561,7 @@ let Calculator = {
 				RowClass = 'info-row';
 
 				RankClass = 'info';
-				
+
 				if (Einzahlungen[Rank] < ForderFPRewards[Rank]) {
 					EinsatzClass = 'error';
 					EinsatzTooltip.push(HTML.i18nReplacer(i18n('Boxes.Calculator.TTPayedTooLess'), { 'payed': Einzahlungen[Rank], 'topay': ForderFPRewards[Rank], 'tooless': ForderFPRewards[Rank] - Einzahlungen[Rank] }));
@@ -573,14 +573,14 @@ let Calculator = {
 				else {
 					EinsatzClass = 'info';
 				}
-				
+
 				EinsatzText = HTML.Format(Einzahlungen[Rank]);
 				if (Einzahlungen[Rank] !== ForderFPRewards[Rank]) {
 					EinsatzText += '/' + HTML.Format(ForderFPRewards[Rank]);
 				}
 				EinsatzText += Calculator.FormatForderRankDiff(ForderRankDiff);
-				
-				
+
+
 				if (ForderRankDiff > 0 && Einzahlungen[Rank] < ForderRankCosts[Rank]) {
 					EinsatzTooltip.push(HTML.i18nReplacer(i18n('Boxes.Calculator.TTForderNegativeProfit'), { 'fpcount': ForderRankDiff, 'totalfp': ForderRankCosts[Rank] }));
 				}
@@ -648,7 +648,7 @@ let Calculator = {
 			// BP+Meds
 
 			RowClass = '';
-					   			 		  		  		 
+
 			if (ForderStates[Rank] === 'NotPossible' && SnipeStates[Rank] === 'NotPossible') {
 				RowClass = 'text-grey';
 			}
@@ -679,7 +679,7 @@ let Calculator = {
 			EinsatzClass = (SnipeRankCosts[Rank] > StrategyPoints.AvailableFP ? 'error' : ''); //Default: rot wenn Vorrat nicht ausreichend, sonst gelb
 			EinsatzText = HTML.Format(SnipeRankCosts[Rank]) //Default: Einsatz
 			EinsatzTooltip = [];
-			
+
 			GewinnClass = (SnipeGewinn >= 0 ? 'success' : 'error'); //Default: Grün wenn >= 0 sonst rot
 			GewinnText = HTML.Format(SnipeGewinn); //Default: Gewinn
 			GewinnTooltip = [];
@@ -761,7 +761,7 @@ let Calculator = {
 			hSnipen.push('<td class="text-center"><strong class="' + KursClass + ' td-tooltip" title="' + KursTooltip.join('<br>') + '">' + KursText + '</strong></td>');
 			hSnipen.push('</tr>');
 		}
-		
+
 		$('#costTableFordern').html(hFordern.join(''));
 		$('#costTableBPMeds').html(hBPMeds.join(''));
 		$('#costTableSnipen').html(hSnipen.join(''));
@@ -774,7 +774,7 @@ let Calculator = {
 			bestRateNettoFp: BestKursNettoFP,
 			bestRateCosts: BestKursEinsatz
 		});
-		
+
 		$('.td-tooltip').tooltip({
 			html: true,
 			container: '#costCalculator'
@@ -784,7 +784,7 @@ let Calculator = {
 
 	/**
 	 * Aktualisiert die GBs in der IndexDB
-	 * 
+	 *
 	 * */
 	RefreshGreatBuildingsDB: async(GreatBuilding) => {
 		await IndexDB.addUserFromPlayerDictIfNotExists(GreatBuilding['playerId'], true);
@@ -950,7 +950,7 @@ let Calculator = {
 					BestKursEinsatz = CurrentGB['bestRateCosts'];
 					BestKurs = Math.round(BestKursEinsatz / BestKursNettoFP * 1000) / 10;
 					Gewinn = Math.round(BestKursNettoFP * arc) - BestKursEinsatz;
-                }							
+                }
 
 				let EraName = GreatBuildings.GetEraName(EntityID);
 
@@ -1035,7 +1035,7 @@ let Calculator = {
 		if (!Calculator.OverviewListenerRegistered) {
 			Calculator.OverviewListenerRegistered = true;
 
-			$('body').on('click', '#CalculatorOverviewTone', function () {
+			$('#costCalculator').on('click', '#CalculatorOverviewTone', function () {
 
 				let disabled = $(this).hasClass('deactivated');
 

--- a/js/web/citymap/js/citymap.js
+++ b/js/web/citymap/js/citymap.js
@@ -121,7 +121,7 @@ let CityMap = {
 
 		menu.append(dropView);
 
-		$('body').on('change', '#menu-view', function(){
+		$('#city-map-overlay').on('change', '#menu-view', function(){
 			let view = $('#menu-view option:selected').data('view');
 
 			$('#grid-outer').attr('data-view', view);
@@ -142,7 +142,7 @@ let CityMap = {
 
 		menu.append(scaleView);
 
-		$('body').on('change', '#scale-view', function(){
+		$('#city-map-overlay').on('change', '#scale-view', function(){
 			let unit = parseInt($('#scale-view option:selected').data('scale'));
 
 			CityMap.ScaleUnit = unit;
@@ -259,7 +259,7 @@ let CityMap = {
 		{
 			if (!MapDataSorted.hasOwnProperty(b) || MapDataSorted[b]['x'] < MinX || MapDataSorted[b]['x'] > MaxX || MapDataSorted[b]['y'] < MinY || MapDataSorted[b]['y'] > MaxY)
 				continue;
-			
+
 			let d = BuildingNamesi18n[ MapDataSorted[b]['cityentity_id'] ],
 
 				x = (MapDataSorted[b]['x']=== undefined ? 0 : ( (parseInt(MapDataSorted[b]['x']) * CityMap.ScaleUnit) / 100 )),

--- a/js/web/greatbuildings/js/greatbuildings.js
+++ b/js/web/greatbuildings/js/greatbuildings.js
@@ -96,22 +96,18 @@ let GreatBuildings =
     BuildBox: () => {
         GreatBuildings.CalcBody();
 
-        if (!GreatBuildings.MainListenerRegistered) {
-            GreatBuildings.MainListenerRegistered = true;
+        $('#greatbuildings').on('blur', '#costFactor', function () {
+            GreatBuildings.ForderBonus = parseFloat($('#costFactor').val());
+            localStorage.setItem('GreatBuildingsForderBonus', GreatBuildings.ForderBonus);
+            GreatBuildings.CalcBody();
+        });
 
-            $('body').on('blur', '#costFactor', function () {
-                GreatBuildings.ForderBonus = parseFloat($('#costFactor').val());
-                localStorage.setItem('GreatBuildingsForderBonus', GreatBuildings.ForderBonus);
+        for (let i = 0; i < GreatBuildings.FPGreatBuildings.length; i++) {
+            $('#greatbuildings').on('blur', '#GreatBuildingsGoodCosts' + i, function () {
+                GreatBuildings.FPGreatBuildings[i].GoodCosts = parseFloat($('#GreatBuildingsGoodCosts' + i).val());
+                localStorage.setItem('GreatBuildingsGoodCosts' + i, GreatBuildings.FPGreatBuildings[i].GoodCosts);
                 GreatBuildings.CalcBody();
             });
-
-            for (let i = 0; i < GreatBuildings.FPGreatBuildings.length; i++) {
-                $('body').on('blur', '#GreatBuildingsGoodCosts' + i, function () {
-                    GreatBuildings.FPGreatBuildings[i].GoodCosts = parseFloat($('#GreatBuildingsGoodCosts' + i).val());
-                    localStorage.setItem('GreatBuildingsGoodCosts' + i, GreatBuildings.FPGreatBuildings[i].GoodCosts);
-                    GreatBuildings.CalcBody();
-                }); 
-            }
         }
     },
 

--- a/js/web/infoboard/js/infoboard.js
+++ b/js/web/infoboard/js/infoboard.js
@@ -142,7 +142,7 @@ let Infoboard = {
         Infoboard.FilterInput();
         Infoboard.ResetBox();
 
-        $('body').on('click', '#infoboxTone', function() {
+        $('#BackgroundInfo').on('click', '#infoboxTone', function() {
 
             let disabled = $(this).hasClass('deactivated');
 
@@ -216,8 +216,7 @@ let Infoboard = {
      *
      */
     FilterInput: () => {
-        $('body').on('change', '.filter-msg', function() {
-
+        $('#BackgroundInfo').on('change', '.filter-msg', function() {
             let active = [];
 
             $('.filter-msg').each(function() {
@@ -252,7 +251,7 @@ let Infoboard = {
      *
      */
     ResetBox: () => {
-        $('body').on('click', '.btn-reset-box', function() {
+        $('#BackgroundInfo').on('click', '.btn-reset-box', function() {
             $('#BackgroundInfoTable tbody').html('');
         });
     }

--- a/js/web/negotiation/js/negotiation.js
+++ b/js/web/negotiation/js/negotiation.js
@@ -57,7 +57,7 @@ let Negotiation = {
 	Message: undefined,
 	MessageClass: 'warning',
 	SortableObj: null,
-	
+
 	WrongGoodsSelected: false,
 	ContinueListing: false,
 	NeedGoodMissmatchConfirm: false,
@@ -85,7 +85,7 @@ let Negotiation = {
 			// CSS in den DOM prügeln
 			HTML.AddCssFile('negotiation');
 
-			$('body').on('click', '.negotation-setting', function(){
+			$('#negotiationBox').on('click', '.negotation-setting', function(){
 				let $this = $(this),
 					id = $this.data('id'),
 					v = $this.prop('checked');
@@ -125,7 +125,7 @@ let Negotiation = {
 		}
 	},
 
-	
+
 	/**
 	 * Berechnungen durchführen
 	 *
@@ -173,7 +173,7 @@ let Negotiation = {
 					TextClass;
 
 				let maxRequired = GoodInfo.canOccur.length * GoodAmount;
-				
+
 				GoodAmount *= Negotiation.CurrentTable.go[i];
 
 				if (Stock === undefined)
@@ -220,7 +220,7 @@ let Negotiation = {
 			Negotiation.MessageClass = 'danger';
 			Negotiation.Message = i18n('Boxes.Negotiation.TableLoadError');
 		}
-		
+
 		// Verhandlungspartner überschrifteh
 		h.push('<tbody>');
 		h.push('<tr class="thead">');
@@ -357,7 +357,7 @@ let Negotiation = {
 					[  0, 255, 0], // Grün
 				];
 				const c = Negotiation.CurrentTable.c;
-				
+
 				let mix = c/100*(colors.length-1);
 				const colorIdx = Math.floor(mix);
 				// mix soll ein Wert zwischen 0 und 1 sein
@@ -372,7 +372,7 @@ let Negotiation = {
 					const colorR = Math.min(255, Math.max(0, Math.round(color1[0]*invMix + color2[0]*mix)));
 					const colorG = Math.min(255, Math.max(0, Math.round(color1[1]*invMix + color2[1]*mix)));
 					const colorB = Math.min(255, Math.max(0, Math.round(color1[2]*invMix + color2[2]*mix)));
-					
+
 					colorVal = `rgba(${colorR}, ${colorG}, ${colorB}, 0.3)`;
 				} else {
 					const color = colors[colorIdx];
@@ -387,7 +387,7 @@ let Negotiation = {
 			for (let place = 0; place < Negotiation.PlaceCount; place++) {
 				const slotSugestion = nextRoundSuggestion[place];
 				const good_id = slotSugestion ? slotSugestion.resourceId : 'empty';
-				
+
 				if (slotSugestion) {
 					h.push('<td class="text-center">');
 					h.push(`<span class="goods-sprite ${good_id}"></span>`);
@@ -414,7 +414,7 @@ let Negotiation = {
 
 		const guess = Guesses[tryNumber];
 		const suggestion = GuessesSuggestions[tryNumber];
-		
+
 		h.push('<tr class="guess goods-opacity">');
 		for (let place = 0; place < Negotiation.PlaceCount; place++) {
 			const SlotGuess = guess[place];
@@ -471,7 +471,7 @@ let Negotiation = {
 			$('#negotiation-Btn').removeClass('hud-btn-red');
 			$('#negotiation-Btn-closed').remove();
 		}
-		
+
 		Negotiation.CurrentTry = 1;
 		Negotiation.Message = null;
 		Negotiation.WrongGoodsSelected = false;
@@ -482,7 +482,7 @@ let Negotiation = {
 
 		const GoodsOrdered = [];
 		Negotiation.GoodsOrdered = GoodsOrdered;
-		
+
 		for (let good_id in negotiationResources) {
 			if (!negotiationResources.hasOwnProperty(good_id)) continue;
 
@@ -526,7 +526,7 @@ let Negotiation = {
 		Negotiation.GetTable(tableName)
 			.then(table => {
 				Negotiation.CurrentTable = table;
-				
+
 				if (table) {
 					Negotiation.updateNextGuess();
 				}
@@ -560,7 +560,7 @@ let Negotiation = {
 
 		let numFreeSlots = 0;
 		for (let data of SlotData) {
-	
+
 			const State      = data.state;
 			const ResourceId = data.resourceId;
 			const SlotID     = data.slotId || 0;
@@ -665,7 +665,7 @@ let Negotiation = {
 				continuationCode += CurrentGuess[PlaceMutation[i]].match;
 			}
 			Negotiation.CurrentTable = Negotiation.CurrentTable.r[continuationCode];
-			
+
 			Negotiation.updateNextGuess();
 		}
 
@@ -705,7 +705,7 @@ let Negotiation = {
 		if (goodA === goodB) return 0;
 		const valA = goodValue(goodA);
 		const valB = goodValue(goodB);
-		
+
 		if (valA === valB) return goodA > goodB ? 1 : -1
 		return valA - valB;
 	},
@@ -904,7 +904,7 @@ let Negotiation = {
 
 				Value = EraID * 100;
             }
-			
+
 			let Stock = ResourceStock[GoodName];
 			if (Stock === undefined || Stock === 0)
 			{
@@ -1038,13 +1038,13 @@ let NegotiationDebugger = {
 		h.push('</select></label>');
 		h.push('<button onclick="NegotiationDebugger.start()">Start</button>');
 		h.push(`Always show Possible Matches: <input type="checkbox" onchange="NegotiationDebugger.changeAlwaysShowPossibleMatch(this)"${Negotiation.ContinueListing?' checked':''} />`);
-		
+
 
 		h.push('<div style="display:grid; grid-template-columns: repeat(auto-fill, 60px);">');
 		const numGoods = data.numGoods;
 		for (let i = 0; i < numGoods; i++) {
 			let good = data.goods[i] || 'empty';
-			
+
 			h.push(`<div>Good ${i+1}:<br/><span onclick="NegotiationDebugger.selectGoodFor(${i})" style="box-sizing: border-box;width: 40px${data.selected===i?'; border: 1px solid red':''}" class="${goodSpriteClass(good)}"></span></div>`);
 		}
 		h.push('</div>');
@@ -1065,17 +1065,17 @@ let NegotiationDebugger = {
 		for (let pos = 0; pos < 5; pos++) {
 			h.push(`<div style="flex-grow:1">`);
 			h.push(`Position ${pos}:<br/>`);
-			
+
 			h.push(`<div style="display: grid; grid-template-columns: repeat(auto-fill, 40px);">`);
 			for (let i = 0; i < numGoods; i++) {
 				let good = data.goods[i] || 'empty';
 				const selected = good === data.submitGoods[pos];
-	
+
 				h.push(`<span onclick="NegotiationDebugger.selectGoodForSubmit(${pos}, ${i})" style="box-sizing: border-box;width: 40px${selected?'; border: 1px solid red':''}" class="${goodSpriteClass(good)}"></span> `);
 			}
 			h.push(`</div>`);
-			
-			
+
+
 			let selectedValue = data.submitValue[pos]
 			if (selectedValue == null) selectedValue = Selectables[Selectables.length-1].value;
 			for (let selectable of Selectables) {
@@ -1221,4 +1221,3 @@ let NegotiationDebugger = {
 		NegotiationDebugger.BuildBox();
 	}
 };
-

--- a/js/web/part-calc/js/part-calc.js
+++ b/js/web/part-calc/js/part-calc.js
@@ -62,7 +62,7 @@ let Parts = {
 		Parts.Show();
 
 		// Für einen Platz wurde der Wert geändert, alle durchsteppen, übergeben und sichern
-		$('body').on('blur', '.arc-percent-input', function(){
+		$('#OwnPartBox').on('blur', '.arc-percent-input', function(){
 			let aprc = [];
 
 			$('.arc-percent-input').each(function () {
@@ -79,13 +79,13 @@ let Parts = {
 
 
 		// Es wird ein externer Platz eingetragen
-		$('body').on('blur', '.ext-part-input', function(){
+		$('#OwnPartBox').on('blur', '.ext-part-input', function(){
 			Parts.collectExternals();
 		});
 
 
 		// eine neuer globaler Arche-Satz wird gewählt
-		$('body').on('click', '.btn-set-arc', function(){
+		$('#OwnPartBox').on('click', '.btn-set-arc', function(){
 			let ArkBonus = parseFloat($(this).data('value'));
 			if (ArkBonus !== ArkBonus) ArkBonus = 0; //NaN => 0
 
@@ -114,10 +114,10 @@ let Parts = {
 				$(this).val(0);
 				v = 0;
 			}
-            
+
             Parts.Input[i] = parseInt(v);
 		});
-        
+
 		// Prüfen ob alle "null" sind
 		const isAllZero = !Parts.Input.some(el => el.value !== 0);
 
@@ -174,7 +174,7 @@ let Parts = {
         for (let i = 0; i < 5; i++) {
             arcs[i] = ((parseFloat(Parts.CurrentBuildingPercents[i]) + 100) / 100);
         }
-        
+
         // Wenn in Rankings nichts mehr steht, dann abbrechen
 		for (let i = 0; i < Parts.Rankings.length; i++) {
 			if (Parts.Rankings[i]['rank'] === undefined || Parts.Rankings[i]['rank'] < 0) { //undefined => Eigentümer oder gelöscher Spieler P1-5, -1 => gelöschter Spieler ab P6 abwärts
@@ -228,7 +228,7 @@ let Parts = {
                 }
             }
         }
-               
+
         Maezens.sort(function (a, b) { return b - a });
 
         for (let i = 0; i < Maezens.length; i++) {
@@ -236,12 +236,12 @@ let Parts = {
                 Maezens.length = Math.max(i, 5);
                 break;
             }
-                        
+
             ExtTotal += Maezens[i];
         }
 
         Rest -= ExtTotal;
-        
+
         for (let i = 0; i < 5; i++) {
             if (FPRewards[i] <= Maezens[i] || Rest <= Maezens[i]) {
 				Eigens[i] = Math.ceil(Rest + (Maezens[i + 1] !== undefined ? Maezens[i + 1] : 0) - Maezens[i]);
@@ -255,7 +255,7 @@ let Parts = {
                 Dangers[i] = Math.floor(0 - Eigens[i]/2);
                 Eigens[i] = 0;
             }
-            
+
             for (let j = Maezens.length - 1; j >= i; j--) {
                 if (Maezens[j] > 0) {
                     Maezens[j + 1] = Maezens[j];
@@ -274,11 +274,11 @@ let Parts = {
         }
 
         if(Rest>0) Eigens[5] = Rest;
-        
+
         EigenTotal = EigenStart;
         for (let i = 0; i < Eigens.length; i++) {
             EigenTotal += Eigens[i];
-        }      
+        }
 
         for (let i = FPRewards.length; i < Maezens; i++)
             FPRewards[i] = 0;
@@ -288,7 +288,7 @@ let Parts = {
 
         for (let i = BPRewards.length; i < Maezens; i++)
             BPRewards[i] = 0;
-        
+
         // Info-Block
         h.push('<table style="width: 100%"><tr><td style="width: 50%">');
 		h.push('<p class="lg-info text-center"><strong>' + BuildingNamesi18n[cityentity_id]['name'] + ' </strong><br>' + (Parts.IsPreviousLevel ? i18n('Boxes.OwnpartCalculator.OldLevel') : i18n('Boxes.OwnpartCalculator.Step') + ' ' + Level + ' &rarr; ' + (parseInt(Level) + 1)) + '</p>');
@@ -422,7 +422,7 @@ let Parts = {
             h.push('<td colspan="5"></td>');
             h.push('</tr>');
         }
-        
+
         h.push('<tbody>');
         h.push('</table>');
 
@@ -495,13 +495,13 @@ let Parts = {
 			'</div>');
 
 		// ---------------------------------------------------------------------------------------------
-		$('body').off("click",'.button-own');
-		$('body').on('click', '.button-own', function(){
+		$('#OwnPartBox').off("click",'.button-own');
+		$('#OwnPartBox').on('click', '.button-own', function(){
 			let copyParts = Parts.CopyFunction(Maezens, Eigens, NonExts, $(this), 'copy');
 			helper.str.copyToClipboard(copyParts);
 		});
-		$('body').off("click",'.button-save-own');
-		$('body').on('click', '.button-save-own', function(){
+		$('#OwnPartBox').off("click",'.button-save-own');
+		$('#OwnPartBox').on('click', '.button-save-own', function(){
 			Parts.CopyFunction(Maezens, Eigens, NonExts, $(this), 'save');
 		});
 

--- a/js/web/plunderer/js/plunderer.js
+++ b/js/web/plunderer/js/plunderer.js
@@ -330,41 +330,37 @@ let Plunderer = {
 
 		Plunderer.Render();
 
-		if (!Plunderer.inited) {
-			$('body').on('click', '#plundererBody .load-1st-page', function () {
-				if (Plunderer.loading) {
-					return;
-				}
-				Plunderer.page = 1;
-				Plunderer.Show();
-				$('#plundererBody').animate({scrollTop: 0}, 'fast');
-			});
+		$('#plunderer').on('click', '#plundererBody .load-1st-page', function () {
+			if (Plunderer.loading) {
+				return;
+			}
+			Plunderer.page = 1;
+			Plunderer.Show();
+			$('#plundererBody').animate({scrollTop: 0}, 'fast');
+		});
 
-			$('body').on('click', '#plundererBody .load-next-page', function () {
-				if (Plunderer.loading) {
-					return;
-				}
-				Plunderer.page++;
-				Plunderer.Show();
-				$('#plundererBody').animate({scrollTop: 0}, 'fast');
-			});
+		$('#plunderer').on('click', '#plundererBody .load-next-page', function () {
+			if (Plunderer.loading) {
+				return;
+			}
+			Plunderer.page++;
+			Plunderer.Show();
+			$('#plundererBody').animate({scrollTop: 0}, 'fast');
+		});
 
-			$('body').on('click', '#plundererBody .select-player', function () {
-				if (Plunderer.loading) {
-					return;
-				}
+		$('#plunderer').on('click', '#plundererBody .select-player', function () {
+			if (Plunderer.loading) {
+				return;
+			}
 
-				const id = $(this).data('value');
+			const id = $(this).data('value');
 
-				Plunderer.page = 1;
-				Plunderer.filterByPlayerId = id ? +id : null;
-				Plunderer.Show();
+			Plunderer.page = 1;
+			Plunderer.filterByPlayerId = id ? +id : null;
+			Plunderer.Show();
 
-				$('#plundererBody').animate({scrollTop: 0}, 'fast');
-			});
-
-			Plunderer.inited = true;
-		}
+			$('#plundererBody').animate({scrollTop: 0}, 'fast');
+		});
 	},
 
 

--- a/js/web/plunderer/js/plunderer.js
+++ b/js/web/plunderer/js/plunderer.js
@@ -208,13 +208,6 @@ FoEproxy.addHandler('OtherPlayerService', 'visitPlayer', async (data, postData) 
  	Plunderer.UpdateBoxIfVisible();
 });
 
-// When you visit your city - remove filter by player
-FoEproxy.addHandler('CityMapService', 'getEntities', async(data, postData) => {
-    Plunderer.page = 1;
-    Plunderer.filterByPlayerId = null;
- 	Plunderer.UpdateBoxIfVisible();
-});
-
 let Plunderer = {
 
 	// Cached last visited player for getting info about city before plundering

--- a/js/web/plunderer/js/plunderer.js
+++ b/js/web/plunderer/js/plunderer.js
@@ -203,11 +203,16 @@ FoEproxy.addHandler('OtherPlayerService', 'visitPlayer', async (data, postData) 
 	const playerData = data.responseData;
 	Plunderer.lastVisitedPlayer = playerData;
 	await Plunderer.collectPlayer(playerData);
-	if ($('#plunderer').length !== 0) {
-		Plunderer.page = 1;
-		Plunderer.filterByPlayerId = playerData.other_player.player_id;
-		Plunderer.Show();
-	}
+	Plunderer.page = 1;
+	Plunderer.filterByPlayerId = playerData.other_player.player_id;
+ 	Plunderer.UpdateBoxIfVisible();
+});
+
+// When you visit your city - remove filter by player
+FoEproxy.addHandler('CityMapService', 'getEntities', async(data, postData) => {
+    Plunderer.page = 1;
+    Plunderer.filterByPlayerId = null;
+ 	Plunderer.UpdateBoxIfVisible();
 });
 
 let Plunderer = {

--- a/js/web/productions/js/productions.js
+++ b/js/web/productions/js/productions.js
@@ -115,7 +115,7 @@ let Productions = {
 
 		let PopulationSum = 0,
 			HappinessSum = 0;
-		
+
 		for(let i in d)
 		{
 			if (d.hasOwnProperty(i) && d[i]['id'] < 2000000000)
@@ -177,7 +177,7 @@ let Productions = {
 
 		for (let i in Productions.BuildingsAll) {
 			let building = Productions.BuildingsAll[i];
-			
+
 			if (building['type'] === 'residential' || building['type'] === 'production') {
 				if (building['products']['money'] !== undefined) {
 					building['products']['money'] = Math.round(building['products']['money'] * Productions.Boosts['money']);
@@ -192,7 +192,7 @@ let Productions = {
 				if (building['motivatedproducts']['supplies'] !== undefined) {
 					building['motivatedproducts']['supplies'] = Math.round(building['motivatedproducts']['supplies'] * Productions.Boosts['supplies']);
 				}
-			}	
+			}
 
 			// Nach Produkt
 			for (let x in building['products']) {
@@ -307,7 +307,7 @@ let Productions = {
 				Products['happiness'] = BuildingData['provided_happiness'] * Faktor;
 			}
 		}
-	
+
 		if (BuildingData['entity_levels'] !== undefined && BuildingData['entity_levels'][d['level']] !== undefined) {
 			let EntityLevel = BuildingData['entity_levels'][d['level']];
 			if (EntityLevel['provided_population'] !== undefined) {
@@ -321,14 +321,14 @@ let Productions = {
 				Products['happiness'] = (Products['happiness'] !== undefined ? Products['happiness'] : 0) + EntityLevel['provided_happiness'] * Faktor;
 			}
 		}
-		
+
         let AdditionalProduct,
 			MotivatedProducts = [];
 
 		for (let ProductName in Products) {
 			MotivatedProducts[ProductName] = Products[ProductName];
 		}
-                
+
         for (let Resource in AdditionalResources) {
 
             if (!AdditionalResources.hasOwnProperty(Resource)) {
@@ -360,7 +360,7 @@ let Productions = {
 
 		Ret.products = Products;
 		Ret.motivatedproducts = MotivatedProducts;
-		
+
         if(d['id'] === '1'){
 			console.log('Products: ', Products);
 		}
@@ -697,7 +697,7 @@ let Productions = {
 			Productions.SortingAllTab();
 
 			// Ein Gebäude soll auf der Karte dargestellt werden
-			$('body').on('click', '.foe-table .show-entity', function () {
+			$('#Productions').on('click', '.foe-table .show-entity', function () {
 				Productions.ShowFunction($(this).data('id'));
 			});
 		});
@@ -753,7 +753,7 @@ let Productions = {
 	 *
 	 */
 	SwitchFunction: ()=>{
-		$('body').on('click', '.change-view', function(){
+		$('#Productions').on('click', '.change-view', function(){
 			let btn = $(this),
 				t = $(this).data('type'),
 				hiddenTb = $('.' + t + '-mode:hidden'),
@@ -821,7 +821,7 @@ let Productions = {
 	 * Blendet je nach Dropdown die Typen ein
 	 */
 	Dropdown: ()=>{
-		$('body').on('change', '#all-drop', function() {
+		$('#Productions').on('change', '#all-drop', function() {
 			let t = $('select#all-drop :selected').data('type');
 
 			if(t === 'all')

--- a/js/web/settings/js/settings.js
+++ b/js/web/settings/js/settings.js
@@ -182,7 +182,7 @@ let Settings = {
 			);
 		}
 
-		$('body').on('click', 'input.setting-check', function(){
+		$('#SettingsBoxBody').on('click', 'input.setting-check', function(){
 			Settings.StoreSettings($(this));
 		});
 	},
@@ -280,13 +280,13 @@ let Settings = {
 			if (!Languages.PossibleLanguages.hasOwnProperty(iso)){
 				break;
 			}
-			
+
 			dp.push('<option value="' + iso + '"' + (MainParser.Language === iso ? ' selected': '') + '>' + Languages.PossibleLanguages[iso] + '</option>');
 		}
 
 		dp.push('</select>');
 
-		$('body').on('change', '#change-lang', function(){
+		$('#SettingsBoxBody').on('change', '#change-lang', function(){
 			let uLng = $(this).val();
 
 			localStorage.setItem('user-language', uLng);
@@ -299,7 +299,7 @@ let Settings = {
 
 
 	CustomerApiCheck: ()=> {
-		$('body').on('change', '[data-id="CustomerApi"]', function(){
+		$('#SettingsBoxBody').on('change', '[data-id="CustomerApi"]', function(){
 			location.reload();
 		});
 	},

--- a/js/web/technologies/js/technologies.js
+++ b/js/web/technologies/js/technologies.js
@@ -71,7 +71,7 @@ let Technologies = {
     AllTechnologies: null,
     UnlockedTechologies: false,
     SelectedEraID: undefined,
-       
+
     Eras: {
         AllAge: 0,
         NoAge: 0,
@@ -157,7 +157,7 @@ let Technologies = {
         Technologies.CalcBody();
 
         // Zeitalter vor und zurück schalten
-        $('body').on('click', '.btn-switchage', function () {
+        $('#technologies').on('click', '.btn-switchage', function () {
 
             $('.btn-switchage').removeClass('btn-default-active');
 
@@ -264,7 +264,7 @@ let Technologies = {
                 OutputList[OutputList.length] = GoodsList[i]['id'];
             }
             OutputList[OutputList.length] = 'asteroid_ice';
-           
+
             for (let i = 0; i < OutputList.length; i++) {
                 let ResourceName = OutputList[i];
                 if (RequiredResources[ResourceName] !== undefined) {


### PR DESCRIPTION
1. Multiple subscription to click and other event because of using $('body'). Replaced withing window id. See https://github.com/dsiekiera/foe-helfer-extension/issues/783 https://github.com/dsiekiera/foe-helfer-extension/issues/764
2. Plunderer: Currently if you visited city and open plunderer than you will see not filtered by visited player. Now filter by player even not open plunderer window. This is good because plunderer window is not alwayes opened and currently I need to revisit player to filter by him.
3. When title of window is too long than dont text wrap but show "..."