### PR TITLE
Add event support in stats

### DIFF
--- a/js/web/_i18n/en.json
+++ b/js/web/_i18n/en.json
@@ -1,4 +1,4 @@
-﻿{
+{
 	"values": {
 		"_Language": "English",
 		"API.GEXChampionship": "GE Guild Ranking info has been updated",
@@ -339,10 +339,12 @@
 		"Boxes.Stats.PeriodTitle.sinceTuesday": "Collected since Tuesday (GE starts on Tuesday)",
 		"Boxes.Stats.PeriodTitle.thisMonth": "Collected this month",
 		"Boxes.Stats.PeriodTitle.today": "Collected Today",
+		"Boxes.Stats.Rewards.Source.__event": "Event",
 		"Boxes.Stats.Rewards.Source.battlegrounds_conquest": "GBG",
 		"Boxes.Stats.Rewards.Source.diplomaticGifts": "Diplomatic Gifts",
 		"Boxes.Stats.Rewards.Source.guildExpedition": "GE",
 		"Boxes.Stats.Rewards.Source.spoilsOfWar": "Spoils of War",
+		"Boxes.Stats.Rewards.SourceTitle.__event": "Rewards from Seasonal or Special Events",
 		"Boxes.Stats.Rewards.SourceTitle.battlegrounds_conquest": "GBG Rewards",
 		"Boxes.Stats.Rewards.SourceTitle.diplomaticGifts": "Diplomatic Gifts (Space Carrier)",
 		"Boxes.Stats.Rewards.SourceTitle.guildExpedition": "GE Relic Rewards (Temple of Relic)",

--- a/js/web/stats/js/stats.js
+++ b/js/web/stats/js/stats.js
@@ -42,7 +42,8 @@ FoEproxy.addHandler('RewardService', 'collectReward', async (data, postData) => 
     await IndexDB.getDB();
 
 	for (let reward of rewards) {
-		if (!Stats.TrackableRewards.some(it => RegExp(it, 'i').test(rewardIncidentSource))) {
+		// default is incident reward
+		if (rewardIncidentSource == 'default') {
 			continue;
 		}
 
@@ -130,15 +131,6 @@ FoEproxy.addHandler('ArmyUnitManagementService', 'getArmyInfo', async (data, pos
 });
 
 let Stats = {
-
-	// More rewards can be tracked later, but for now lets track few
-	TrackableRewards: [
-		'.*event.*', // any seasonal event
-		'diplomaticGifts', // Asteroid Age's GB reward
-		'battlegrounds_conquest', // Battle ground
-		'guildExpedition', // Temple of Relics
-		'spoilsOfWar' // Himeji Castle
-	],
 
 	ResMap: {
 		NoAge: ['money', 'supplies', 'tavern_silver', 'medals', 'premium'],

--- a/js/web/stats/js/stats.js
+++ b/js/web/stats/js/stats.js
@@ -42,7 +42,7 @@ FoEproxy.addHandler('RewardService', 'collectReward', async (data, postData) => 
     await IndexDB.getDB();
 
 	for (let reward of rewards) {
-		if (!Stats.TrackableRewards.includes(rewardIncidentSource)) {
+		if (!Stats.TrackableRewards.some(it => RegExp(it, 'i').test(rewardIncidentSource))) {
 			continue;
 		}
 
@@ -133,6 +133,7 @@ let Stats = {
 
 	// More rewards can be tracked later, but for now lets track few
 	TrackableRewards: [
+		'.*event.*', // any seasonal event
 		'diplomaticGifts', // Asteroid Age's GB reward
 		'battlegrounds_conquest', // Battle ground
 		'guildExpedition', // Temple of Relics
@@ -509,6 +510,7 @@ ${sourceBtns.join('')}
 		}));
 
 		const btnsRewardSelect = [
+			'__event',
 			'battlegrounds_conquest', // Battle ground
 			'guildExpedition', // Temple of Relics
 			'spoilsOfWar', // Himeji Castle
@@ -1073,13 +1075,16 @@ ${sourceBtns.join('')}
 		let data = await IndexDB.db.statsRewards.where('date').above(startDate).toArray();
 
 		const rewardTypes = await IndexDB.db.statsRewardTypes.toArray();
-		const rewardSources = ['battlegrounds_conquest', 'guildExpedition', 'spoilsOfWar', 'diplomaticGifts'];
 		const groupedByRewardSource = {};
 
 		data.forEach(it => {
-			groupedByRewardSource[it.type] = groupedByRewardSource[it.type] || {};
-			groupedByRewardSource[it.type][it.reward] = groupedByRewardSource[it.type][it.reward] || 0;
-			groupedByRewardSource[it.type][it.reward]++;
+            let type = it.type;
+            if (/event/i.test(type)) {
+                type = '__event';
+            }
+			groupedByRewardSource[type] = groupedByRewardSource[type] || {};
+			groupedByRewardSource[type][it.reward] = groupedByRewardSource[type][it.reward] || 0;
+			groupedByRewardSource[type][it.reward]++;
 		});
 
 		const seriesMapBySource = groupedByRewardSource[rewardSource] || {};


### PR DESCRIPTION
It is too late.. but still good to add support rewards from event

![event](https://user-images.githubusercontent.com/213405/81281632-c4bae980-9062-11ea-811c-f5755bd8a74c.jpg)

Current know reward types:
```js
    La.CONTEXT_DEFAULT = "default";
    La.CONTEXT_GUILD_EXPEDITION = "guildExpedition";
    La.CONTEXT_CHEST_EVENT = "chestEvent";
    La.CONTEXT_ARCHEOLOGY_EVENT = "archeologyEvent";
    La.CONTEXT_ARCHEOLOGY_EVENT_AUTO_COLLECT = "archeologyEventAutoCollect";
    La.CONTEXT_HALLOWEEN_EVENT = "halloweenEvent";
    La.CONTEXT_HALLOWEEN_EVENT_AUTO_COLLECT = "halloweenEventAutoCollect";
    La.CONTEXT_CHEST_EVENT_GRAND_PRIZE = "chestEventGrandPrize";
    La.CONTEXT_SUMMER_EVENT = "summerEvent";
    La.CONTEXT_SUMMER_EVENT_GRAND_PRIZE = "summerEventGrandPrize";
    La.CONTEXT_WINTER_EVENT = "winterEvent";
    La.CONTEXT_WINTER_EVENT_GRAND_PRIZE = "winterEventGandPrize";
    La.CONTEXT_CARNIVAL_EVENT = "carnivalEvent";
    La.CONTEXT_SPRING_EVENT = "springEvent";
    La.CONTEXT_FORGE_BOWL_EVENT = "forgeBowlEvent";
    La.CONTEXT_DAILY_CHALLENGES = "dailyChallenges";
    La.CONTEXT_GRAND_PRIZE = "grandPrize";
    La.CONTEXT_SPOILS_OF_WAR = "spoilsOfWar";
    La.CONTEXT_EXPLORATION_SITE = "explorationSite";
    La.CONTEXT_ANTIQUES_DEALER = "antiquesDealer";
    La.CONTEXT_MERCHANT = "merchant";
    La.CONTEXT_BATTLEGROUNDS_CONQUEST = "battlegrounds_conquest";
    La.CONTEXT_QUEST_LIBRARY = "quest_library";
    La.CONTEXT_ST_PATRICKS_EVENT = "st_patricks_event";
    La.CONTEXT_ST_PATRICKS_EVENT_GRAND_PRIZE = "st_patricks_event_grand_prize";
    La.CONTEXT_DIPLOMATIC_GIFTS = "diplomaticGifts";
```

as you see most event reward context have word "event" so I simply use regexp to white list them:
```js
	TrackableRewards: [
		'.*event.*', // any seasonal event
		'diplomaticGifts', // Asteroid Age's GB reward
		'battlegrounds_conquest', // Battle ground
		'guildExpedition', // Temple of Relics
``` 