### PR TITLE
Added the "max level" value to the cost calculator

### DIFF
--- a/js/web/calculator/js/calculator.js
+++ b/js/web/calculator/js/calculator.js
@@ -166,7 +166,7 @@ let Calculator = {
 			h.push('<br>' + Calculator.PlayerName + (Calculator.ClanName !== undefined ? ' - ' + Calculator.ClanName : ''));
 		}
 		h.push('</strong><br>' + i18n('Boxes.Calculator.Step') + '' + Level + ' &rarr; ' + (Level + 1));
-		h.push('<br>' + i18n('Boxes.Calculator.MaxLevel', 'Max Level: ') + Calculator.CityMapEntity.max_level + '</p>');
+		h.push('<br>' + i18n('Boxes.Calculator.MaxLevel', 'Max Level') + ': ' + MaxLevel + '</p>');
 
         // FP im Lager
         h.push('<p>' + i18n('Boxes.Calculator.AvailableFP') + ': <strong class="fp-storage">' + HTML.Format(StrategyPoints.AvailableFP) + '</strong></p>');

--- a/js/web/calculator/js/calculator.js
+++ b/js/web/calculator/js/calculator.js
@@ -156,6 +156,7 @@ let Calculator = {
         // BuildingName konnte nicht aus der BuildingInfo geladen werden
 		let BuildingName = BuildingNamesi18n[Calculator.CityMapEntity['cityentity_id']]['name'];
 		let Level = (Calculator.CityMapEntity['level'] !== undefined ? Calculator.CityMapEntity['level'] : 0);
+		let MaxLevel = (Calculator.CityMapEntity['max_level'] !== undefined ? Calculator.CityMapEntity['max_level'] : 0);
 
         h.push('<div class="text-center dark-bg" style="padding:5px 0 3px;">');
 
@@ -164,7 +165,8 @@ let Calculator = {
 		if (Calculator.PlayerName !== undefined) {
 			h.push('<br>' + Calculator.PlayerName + (Calculator.ClanName !== undefined ? ' - ' + Calculator.ClanName : ''));
 		}
-		h.push('</strong><br>' + i18n('Boxes.Calculator.Step') + '' + Level + ' &rarr; ' + (Level + 1) + '</p>');
+		h.push('</strong><br>' + i18n('Boxes.Calculator.Step') + '' + Level + ' &rarr; ' + (Level + 1));
+		h.push('<br>' + i18n('Boxes.Calculator.MaxLevel', 'Max Level: ') + Calculator.CityMapEntity.max_level + '</p>');
 
         // FP im Lager
         h.push('<p>' + i18n('Boxes.Calculator.AvailableFP') + ': <strong class="fp-storage">' + HTML.Format(StrategyPoints.AvailableFP) + '</strong></p>');


### PR DESCRIPTION
This tweak adds the "max_level" value to the cost calculator to display the open levels of a Great Building, which will make it much easier/faster to find new friends suitable for sniping.

![image](https://user-images.githubusercontent.com/722049/81504951-820c4200-92ec-11ea-82e5-11932b0d6213.png)
