### PR TITLE
Inventory tracker to fix bugs 1025, 1044, 1059, 1089, 1097 as well as 1080 

### DIFF
--- a/js/inject.js
+++ b/js/inject.js
@@ -184,6 +184,7 @@
 				'hidden-rewards',
 				'greatbuildings',
                 'alerts',
+				'inventory-tracker',
 			];
 
 			// Scripte laden (nacheinander)

--- a/js/web/_i18n/de.json
+++ b/js/web/_i18n/de.json
@@ -302,6 +302,7 @@
 		"Boxes.Productions.Headings.street": "Straßen",
 		"Boxes.Productions.Headings.size": "Größe",
 		"Boxes.Productions.Headings.efficiency": "Effizienz",
+		"Boxes.Productions.Headings.area": "Fläche",
 		"Boxes.Productions.ModeCurrent": "Aktuell",
 		"Boxes.Productions.ModeDaily": "Tagesprod.",
 		"Boxes.Productions.ModeGroups": "Gruppiert",

--- a/js/web/_i18n/en.json
+++ b/js/web/_i18n/en.json
@@ -302,6 +302,7 @@
 		"Boxes.Productions.Headings.street": "Roads",
 		"Boxes.Productions.Headings.size": "Size",
 		"Boxes.Productions.Headings.efficiency": "Efficiency",
+		"Boxes.Productions.Headings.area": "Area",
 		"Boxes.Productions.ModeCurrent": "Current",
 		"Boxes.Productions.ModeDaily": "Daily prod.",
 		"Boxes.Productions.ModeGroups": "Group",

--- a/js/web/_i18n/en.json
+++ b/js/web/_i18n/en.json
@@ -14,7 +14,7 @@
 		"Boxes.Alerts.Form.Body": "Body",
 		"Boxes.Alerts.Form.Create": "Create",
 		"Boxes.Alerts.Form.CreateAlert": "Create Alert",
-		"Boxes.Alerts.Form.CreateAllSectors": "???", //Todo: Translate
+		"Boxes.Alerts.Form.CreateAllSectors": "Create For All Sectors",
 		"Boxes.Alerts.Form.CreateNewAlert": "Create New Alert",
 		"Boxes.Alerts.Form.Datetime": "Date &amp; Time",
 		"Boxes.Alerts.Form.Delete": "Delete",
@@ -49,8 +49,8 @@
 		"Boxes.Alerts.Preferences.Battlegrounds.Info": "Send an instant alert when there is a high activity in the Guild Battlegrounds (for example, 10 fights in a single sector within 5 seconds). Please note that this function works only when the Guild Battlegrounds are open in game!",
 		"Boxes.Alerts.Preferences.Battlegrounds.Title": "Guild Battlegrounds Tracker",
 		"Boxes.Alerts.Preferences.ComingSoon": "Coming soon...",
-		"Boxes.Alerts.Preferences.Early.Info": "???", //Todo: Translate
-		"Boxes.Alerts.Preferences.Early.Title": "???", //Todo: Translate
+		"Boxes.Alerts.Preferences.Early.Info": "Automatically generated alert times (Antiques Dealer, Guild Battlegrounds etc) will use this offset to send notification before the event actually happens. For example, setting this value to 30 (seconds), Auction alerts will be displayed 30s before the auction actually ends!",
+		"Boxes.Alerts.Preferences.Early.Title": "Notify Early Offset",
 		"Boxes.Alerts.Preferences.InGame.Info": "Show in-game notification instead of the native Desktop notification when the game window is focused",
 		"Boxes.Alerts.Preferences.InGame.Title": "In-game Notifications",
 		"Boxes.Alerts.Preferences.MenuIcon.Info": "Show the next alert countdown as an overlay of the Main Menu icon",

--- a/js/web/_main/js/_main.js
+++ b/js/web/_main/js/_main.js
@@ -707,37 +707,6 @@ const FoEproxy = (function () {
 		MainParser.setGoodsData(data.responseData);
 	});
 
-
-	FoEproxy.addHandler('InventoryService', 'getItems', (data, postData) => {
-		MainParser.UpdateInventory(data.responseData);
-		StrategyPoints.GetFromInventory();
-	});
-
-
-	FoEproxy.addHandler('InventoryService', 'getInventory', (data, postData) => {
-		MainParser.UpdateInventory(data.responseData.inventoryItems);
-		StrategyPoints.GetFromInventory();
-	});
-
-
-	FoEproxy.addHandler('InventoryService', 'getItemAmount', (data, postData) => {
-		let ID = data.responseData[0];
-		let Value = data.responseData[1];
-
-		if (!MainParser.Inventory[ID]) MainParser.Inventory[ID] = [];
-		MainParser.Inventory[ID]['inStock'] = Value;
-		StrategyPoints.GetFromInventory();
-	});
-
-
-	FoEproxy.addHandler('NoticeIndicatorService', 'removePlayerItemNoticeIndicators', (data, postData) => {
-		for (let i in MainParser.Inventory) {
-			if (!MainParser.Inventory.hasOwnProperty(i)) continue;
-
-			MainParser.Inventory[i]['new'] = 0;
-        }
-	});
-
 	// --------------------------------------------------------------------------------------------------
 	// --------------------------------------------------------------------------------------------------
 	// Es wurde das LG eines Mitspielers angeklickt, bzw davor die Übersicht
@@ -1937,13 +1906,13 @@ let MainParser = {
 	*
 	* @param Items
 	*/
-	UpdateInventory: (Items) => {
-		MainParser.Inventory = {};
-		for (let i = 0; i < Items.length; i++) {
-			let ID = Items[i]['id'];
-			MainParser.Inventory[ID] = Items[i];
-		}
-    },
+    // UpdateInventory: (Items) => {
+		// MainParser.Inventory = {};
+		// for (let i = 0; i < Items.length; i++) {
+		// 	let ID = Items[i]['id'];
+		// 	MainParser.Inventory[ID] = Items[i];
+		// }
+    // },
 
 
 	/**

--- a/js/web/calculator/js/calculator.js
+++ b/js/web/calculator/js/calculator.js
@@ -193,7 +193,7 @@ let Calculator = {
 		if (Calculator.PlayerName !== undefined) {
 			h.push('<br>' + Calculator.PlayerName + (Calculator.ClanName !== undefined ? ' - ' + Calculator.ClanName : ''));
 		}
-		h.push('</strong><br>' + i18n('Boxes.Calculator.Step') + '' + Level + ' &rarr; ' + (Level + 1) + ' ' + i18n('Boxes.Calculator.MaxLevel') + ': ' + MaxLevel + '</p>');
+        h.push('</strong><br>' + i18n('Boxes.Calculator.Step') + '' + Level + ' &rarr; ' + (Level + 1) + ' ' + i18n('Boxes.Calculator.MaxLevel') + ': ' + MaxLevel + '</p>');
 
         // FP im Lager
         h.push('<p>' + i18n('Boxes.Calculator.AvailableFP') + ': <strong class="fp-storage">' + HTML.Format(StrategyPoints.AvailableFP) + '</strong></p>');

--- a/js/web/infoboard/js/infoboard.js
+++ b/js/web/infoboard/js/infoboard.js
@@ -26,6 +26,25 @@ FoEproxy.addHandler('ConversationService', 'getOverview', (data, postData) => {
     MainParser.setConversations(data.responseData);
 });
 
+// when a great building where the player has invested has been levelled
+FoEproxy.addHandler('BlueprintService','newReward', (data, postData) => {
+
+    if ( data && data['responseData'] && data['responseData']['strategy_point_amount'] ) {
+        // save the number of returned FPs to show in the infoboard message
+        Info.ReturnFPPoints = data.responseData.strategy_point_amount;
+
+        // If the Info.OtherPlayerService_newEventgreat_building_contribution ran earlier than this
+        // the ReturnFPPoints was 0 so no message was posted. Therefore recreate the message using
+        // the stored data (and the correct value of Info.ReturnFPPoints) and post it
+        if ( Info.ReturnFPMessageData ){
+            let bd = Info.OtherPlayerService_newEventgreat_building_contribution( Info.ReturnFPMessageData );
+            Info.ReturnFPMessageData = null;
+            Infoboard.PostMessage(bd);
+        }
+    }
+
+});
+
 /**
  *
  * @type {{init: Infoboard.init, Show: InfoBoard.Show, InjectionLoaded: boolean, ResetBox: Infoboard.ResetBox, BoxContent: Infoboard.BoxContent, FilterInput: Infoboard.FilterInput, SoundFile: HTMLAudioElement, Box: Infoboard.Box, PlayInfoSound: null}}
@@ -194,6 +213,11 @@ let Infoboard = {
             return;
         }
 
+        Infoboard.PostMessage(bd);
+    },
+
+    PostMessage: (bd) => {
+
         if ($('#BackgroundInfo').length > 0) {
             let status = $('input[data-type="' + bd['class'] + '"]').prop('checked'),
                 tr = $('<tr />').addClass(bd['class']),
@@ -215,8 +239,8 @@ let Infoboard = {
                 Infoboard.SoundFile.play();
             }
         }
-    },
 
+    },
 
     /**
      * Filter für Message Type
@@ -278,7 +302,7 @@ let Info = {
      * und müssen gesammelt werden
      */
     ReturnFPPoints: 0,
-
+    ReturnFPMessageData: null,
 
     /**
      * Jmd hat in einer Auktion mehr geboten
@@ -343,52 +367,6 @@ let Info = {
             msg: Info.GetConversationHeader(d['conversationId'], d['sender']['name']) + msg
         };
     },
-
-
-    /**
-    * Neue Item Information
-    *
-    * @param d
-    */
-    InventoryService_getItem: (d) => {
-        if (!d['id']) return;
-
-        MainParser.Inventory[d['id']] = d;
-        MainParser.Inventory[d['id']]['inStock'] = 0; //inStock auf 0 setzen, da es gleich darauf in NoticeIndicatorService_getPlayerNoticeIndicators aktualisiert und sonst doppelt gezählt wird
-    },
-
-
-    /**
-     * LG Level Up
-     *
-     * @param d
-     */
-    NoticeIndicatorService_getPlayerNoticeIndicators: (d) => {
-        let OldFPInventory = StrategyPoints.InventoryFP;
-
-        for (let i in d) {
-            if (!d.hasOwnProperty(i)) continue;
-
-            let Item = d[i];
-            let ID = Item['itemId'];
-            if (!ID) continue;
-
-            let Amount = Item['amount'];
-            if (!Amount) continue;
-
-            if (!MainParser.Inventory[ID]) MainParser.Inventory[ID] = [];
-            let OldNew = MainParser.Inventory[ID]['new'] | 0;
-            MainParser.Inventory[ID]['new'] = Amount;
-
-            if (!MainParser.Inventory[ID]['inStock']) MainParser.Inventory[ID]['inStock'] = 0;
-            MainParser.Inventory[ID]['inStock'] += Amount - OldNew;
-        }
-
-        StrategyPoints.GetFromInventory();
-
-        Info.ReturnFPPoints = StrategyPoints.InventoryFP - OldFPInventory;
-    },
-
 
     /**
      * Auf der GG-Map kämpft jemand
@@ -483,12 +461,10 @@ let Info = {
      * @returns {{class: 'level', msg: string, type: string}}
      */
     OtherPlayerService_newEventgreat_building_contribution: (d) => {
+
         let newFP = Info.ReturnFPPoints;
 
-        // zurück setzen
-        Info.ReturnFPPoints = 0;
-
-        return {
+        let data = {
             class: 'level',
             type: 'Level-Up',
             msg: HTML.i18nReplacer(
@@ -501,6 +477,19 @@ let Info = {
                 }
             )
         };
+
+        // If the ReturnFPPoints is 0 the BlueprintService.newReward handler has not run yet
+        // so store the data and post the message from that handler (using the stored data)
+        if ( Info.ReturnFPPoints == 0 ){
+            Info.ReturnFPMessageData = d;
+            return undefined;
+        }
+
+        // zurück setzen
+        Info.ReturnFPPoints = 0;
+        Info.ReturnFPMessageData = null;
+
+        return data;
     },
 
 
@@ -576,3 +565,4 @@ let Info = {
         return '';
     }
 };
+

--- a/js/web/inventory-tracker/js/inventory-tracker.js
+++ b/js/web/inventory-tracker/js/inventory-tracker.js
@@ -1,0 +1,240 @@
+InventoryTracker = function(){
+
+    // Known issues:
+    //  - when there are no 5-fp packs in the inventory and the player receives a new 5-fp pack
+    //  from a (recurring) quest, the new pack will not be counted. It is added to the inventory
+    //  and it will be correctly counted when the inventory updates.
+    //  Unfortunately, the InventoryService.getItem is not triggered for the reward collection, so there
+    //  is no way to correctly initialize the inventory (we don't know that we've received a 5-fp pack
+    //  because there is no matching item id in the inventory)
+    //  Maybe we could guess, i.e. if the 10-fp and 2-fp packs are in the inventory and we add an unlabeled
+    //  fp pack with an id different than the other two (10-fp and 2-fp packs) we could guess that a 5-fp
+    //  pack has been added
+    //  - the above (guessing game) works only if the fp pack ids don't change, but I've seen them change
+    //  occasionally
+
+    // private
+    let tmp = {
+        debug: false,
+        aux: {
+            addInventoryAmount: (id, amount) => {
+
+                if ( !tmp.inventory[id] ){
+                    tmp.aux.setInventoryAmount(id, amount);
+                }
+                let old = tmp.new.get(id);
+                let newAmount = tmp.inventory[id].inStock + amount - old;
+                tmp.new.set(id, amount);
+                tmp.aux.setInventoryAmount(id, newAmount);
+            },
+            getInventoryFp: () => {
+                let total = 0;
+
+                for ( let [id, item] of Object.entries( tmp.inventory ) ){
+                    let gain = 0;
+                    switch( item['itemAssetName'] ){
+                        case 'small_forgepoints' : { gain = 2; break; }
+                        case 'medium_forgepoints' : { gain = 5; break; }
+                        case 'large_forgepoints' : { gain = 10; break; }
+                    }
+                    let itemNew = item.new | 0;
+                    total += ( item.inStock - itemNew ) * gain;
+                }
+                return total;
+            },
+            setInventoryAmount: (id, amount) => {
+
+                if ( !id ){ return; }
+
+                if ( !tmp.inventory[id] ){
+                    tmp.inventory[id] = { inStock: 0 };
+                }
+                tmp.inventory[id].inStock = amount;
+            },
+        },
+        action: {
+            init: () => {
+                if ( tmp.initialized ){ return; }
+                tmp.initialized = true;
+            },
+            indicators: {
+                load: (data) => {
+                    for( var i = 0; i < data.length; i++ ){
+                        let item = data[i];
+                        tmp.new.set( item['itemId'], item['amount'] );
+                    }
+                    tmp.new.initialized = true;
+                },
+            },
+            inventory: {
+                addItem: (data) => {
+                    if( !data['id'] ){ return; }
+
+                    data.inStock = 0;
+                    data.new = 0;
+                    tmp.inventory[data['id']] = data;
+                },
+                resetNew: () => {
+                    tmp.new.reset();
+                    for ( let [id, item] of Object.entries( tmp.inventory ) ){
+                        tmp.inventory[id].new = 0;
+                    }
+                },
+                set: (data) => {
+
+                    tmp.inventory = {};
+
+                    if ( !data ){ return; }
+                    let items = data.filter( item => item.itemAssetName.indexOf( 'forgepoints' ) > -1 );
+                    for ( let [index, item] of items.entries() ) {
+                        tmp.inventory[ item.id ] = item;
+                    }
+                    tmp.fp.total = tmp.aux.getInventoryFp();
+                    tmp.updateFpStockPanel();
+                },
+                update: (data) => {
+
+                    if (data && ( data.length % 2 == 0 )){
+                        for( var i = 0; i < data.length; i = i+2 ){
+                            let id = data[i];
+                            let value = data[i+1];
+                            tmp.aux.setInventoryAmount(id, value);
+                        }
+                    }
+                    tmp.fp.total = tmp.aux.getInventoryFp();
+                    tmp.updateFpStockPanel();
+                },
+                updateRewards: (data) => {
+                    if ( !data ){ return };
+                    for ( var i = 0; i < data.length; i++ ){
+                        let item = data[i];
+                        let id = item['itemId'];
+                        let value = item['amount'];
+                        if ( id && value ) {
+                            tmp.aux.addInventoryAmount( id, value );
+                        }
+                    }
+                    tmp.fp.total = tmp.aux.getInventoryFp();
+                    tmp.updateFpStockPanel();
+                },
+            },
+        },
+        fp: {
+            total: 0
+        },
+        handlers: {
+            addInventoryHandlers: () => {
+
+                FoEproxy.addHandler('InventoryService', 'getItems', (data, postData) => {
+                    tmp.action.init();
+                    tmp.log('InventoryService.getItems');
+                    tmp.log(data.responseData);
+                    tmp.action.inventory.set(data.responseData);
+                    // load new values
+                    tmp.new.init();
+                });
+
+                FoEproxy.addHandler('InventoryService', 'getItemsByType', (data, postData) => {
+                    tmp.log('InventoryService.getItemsByType');
+                    tmp.log(data.responseData);
+                    tmp.action.inventory.set(data.responseData);
+                });
+
+                FoEproxy.addHandler('InventoryService', 'getItemsByType', (data, postData) => {
+                    tmp.log('InventoryService.getItemsByType');
+                    tmp.log(data.responseData);
+                    tmp.action.inventory.set(data.responseData);
+                });
+
+                FoEproxy.addHandler('InventoryService', 'getItemAmount', (data, postData) => {
+                    tmp.log('InventoryService.getItemAmount');
+                    tmp.log(data.responseData);
+                    tmp.action.inventory.update(data.responseData);
+                });
+            },
+            addOtherHandlers: () => {
+
+                FoEproxy.addHandler('NoticeIndicatorService', 'removePlayerItemNoticeIndicators', (data, postData) => {
+                    tmp.log('NoticeIndicatorService.removePlayerItemNoticeIndicators');
+                    tmp.log(data.responseData);
+                    tmp.action.inventory.resetNew();
+                });
+                FoEproxy.addHandler('NoticeIndicatorService', 'getPlayerNoticeIndicators', (data, postData) => {
+                    tmp.log('NoticeIndicatorService.getPlayerNoticeIndicators');
+                    tmp.log(data.responseData);
+                    tmp.action.indicators.load(data.responseData);
+                });
+            },
+            addRawHandlers: () => {
+
+                FoEproxy.addRawWsHandler( data => {
+                    if ( !data || !data[0] ){ return; }
+                    let requestClass = data[0].requestClass;
+                    let requestMethod = data[0].requestMethod;
+                    if ( requestClass == 'NoticeIndicatorService' && requestMethod == 'getPlayerNoticeIndicators' ){
+                        tmp.log( 'NoticeIndicatorService.getPlayerNoticeIndicators' );
+                        tmp.log( data[0].responseData );
+                        if ( data[0].responseData ) {
+                            tmp.action.inventory.updateRewards( data[0].responseData );
+                        }
+                    }
+                    if ( requestClass == 'InventoryService' && requestMethod == 'getItem' ){
+                        tmp.log('InventoryService.getItem');
+                        tmp.log( data[0].responseData );
+                        if( data[0].responseData ){
+                            tmp.action.inventory.addItem( data[0].responseData );
+                        }
+                    }
+                });
+            },
+        },
+        initialized: false,
+        // keep a copy of the inventory while this is work-in-progress
+        inventory: {},
+        new: {
+            initialized: false,
+            data: {},
+            get: (id) => {
+                return tmp.new.data[id] | 0;
+            },
+            init: () => {
+                if ( tmp.new.initialized ){ return; }
+                tmp.new.reset();
+            },
+            reset: () => {
+                tmp.new.data = {};
+            },
+            set: (id, value) => {
+                tmp.new.data[id] = value;
+            },
+        },
+        updateFpStockPanel: () => {
+            StrategyPoints.RefreshBar( tmp.fp.total );
+            tmp.log(`Set ForgePointBar: ${tmp.fp.total} `);
+        },
+        log: (o) => {
+            if ( tmp.debug ){ console.log(o); }
+        }
+    };
+
+
+    // public
+    let pub = {
+        debug: () => {
+            return {
+                fp: tmp.fp.total,
+                inventory: tmp.inventory,
+                new: tmp.new.data,
+            }
+        },
+        init: () => {
+            tmp.handlers.addInventoryHandlers();
+            tmp.handlers.addOtherHandlers();
+            tmp.handlers.addRawHandlers();
+        },
+    };
+
+    return pub;
+}();
+
+InventoryTracker.init();

--- a/js/web/productions/js/productions.js
+++ b/js/web/productions/js/productions.js
@@ -453,9 +453,7 @@ let Productions = {
 				countAllMotivated = 0,
 				sizes = [];
 
-
 				var MapData = MainParser.CityMapData;
-				//Vloxxity
 				for(var index = 0; index < MapData.length; ++index)
 				{
 					var d = BuildingNamesi18n[ MapData[index]['cityentity_id'] ];
@@ -480,7 +478,8 @@ let Productions = {
 						rowA.push('<tr>');
 						rowA.push('<td data-text="' + buildings[i]['name'].cleanup() + '">' + buildings[i]['name'] + '</td>');
 						rowA.push('<td class="text-right is-number" data-number="' + MotivatedProductCount + '">' + HTML.Format(ProductCount) + (ProductCount !== MotivatedProductCount ? '/' + HTML.Format(MotivatedProductCount) : '') + '</td>');
-									var size = sizes[buildings[i]['eid']];
+						
+						var size = sizes[buildings[i]['eid']];
 						var efficiency = (MotivatedProductCount/size);
 					
 						rowA.push('<td class="text-right is-number" data-number="' + size + '">' + size + '</td>');						
@@ -542,11 +541,17 @@ let Productions = {
 					if (groups.hasOwnProperty(i)) {
 						let ProductCount = Productions.GetDaily(groups[i]['products'], groups[i]['dailyfactor'], type),
 							MotivatedProductCount = Productions.GetDaily(groups[i]['motivatedproducts'], groups[i]['dailyfactor'], type);
-
+						console.log(groups[i]);
+						var size = sizes[groups[i]['eid']];
+						var efficiency = (MotivatedProductCount/(size*groups[i]['count']));
+					
+									
 						let tds = '<tr>' +
 							'<td class="text-right is-number" data-number="' + groups[i]['count'] + '">' + groups[i]['count'] + 'x </td>' +
-							'<td colspan="4" data-text="' + groups[i]['name'].cleanup() + '">' + groups[i]['name'] + '</td>' +
+							'<td colspan="3" data-text="' + groups[i]['name'].cleanup() + '">' + groups[i]['name'] + '</td>' +
 							'<td class="is-number" data-number="' + MotivatedProductCount + '">' + HTML.Format(ProductCount) + (ProductCount !== MotivatedProductCount ? '/' + HTML.Format(MotivatedProductCount) : '') + '</td>' +
+							'<td class="text-right is-number" data-number="' + (size*groups[i]['count']) + '">' + (size*groups[i]['count']) + '</td>'+
+							'<td class="text-right is-number" data-number="' + efficiency + '">' + efficiency.toFixed(3) + '</td>'+
 							'</tr>';
 
 						rowB.push(tds);
@@ -628,7 +633,7 @@ let Productions = {
 
 				table.push('<tr class="other-header">');
 
-				table.push('<th colspan="2">');
+				table.push('<th colspan="3">');
 
 				if (type !== 'population' && type !== 'happiness') {
 					if (Productions.ShowDaily) {
@@ -643,7 +648,7 @@ let Productions = {
 				table.push('</th>');
 
 				table.push('<th colspan="2"></th>');
-				table.push('<th colspan="3" class="text-right"><strong>' + Productions.GetGoodName(type) + ': ' + HTML.Format(countAll) + (countAll !== countAllMotivated ? '/' + HTML.Format(countAllMotivated) : '') + '</strong></th>');
+				table.push('<th colspan="4" class="text-right"><strong>' + Productions.GetGoodName(type) + ': ' + HTML.Format(countAll) + (countAll !== countAllMotivated ? '/' + HTML.Format(countAllMotivated) : '') + '</strong></th>');
 				table.push('</tr>');
 
 				table.push('</thead>');
@@ -677,9 +682,11 @@ let Productions = {
 
 				// Sortierung - Gruppiert-Header
 				table.push('<tr class="sorter-header">');
-				table.push('<th class="game-cursor text-right is-number" data-type="' + type + '-groups">' + i18n('Boxes.Productions.Headings.number') + '</th>');
-				table.push('<th class="ascending game-cursor" colspan="4" data-type="' + type + '-groups">Name</th>');
-				table.push('<th class="is-number game-cursor" data-type="' + type + '-groups">' + i18n('Boxes.Productions.Headings.amount') + '</th>');
+				table.push('<th colspan="1" class="game-cursor text-right is-number" data-type="' + type + '-groups">' + i18n('Boxes.Productions.Headings.number') + '</th>');
+				table.push('<th colspan="3" class="ascending game-cursor" data-type="' + type + '-groups">Name</th>');
+				table.push('<th colspan="1" class="is-number game-cursor" data-type="' + type + '-groups">' + i18n('Boxes.Productions.Headings.amount') + '</th>');
+				table.push('<th colspan="1" class="is-number game-cursor text-right" data-type="' + type + '-groups">' + i18n('Boxes.Productions.Headings.area') + '</th>');
+				table.push('<th colspan="1" class="is-number game-cursor text-right" data-type="' + type + '-groups">' + i18n('Boxes.Productions.Headings.efficiency') + '</th>');
 				table.push('</tr>');
 
 				table.push( rowB.join('') );


### PR DESCRIPTION
This adds an Inventory Tracker (for FPs packs), moves service listeners and other relevant code into `inventory-tracker.js` (but it is self contained could be as well just copy/pasted at the bottom of `strategy-points.js`)

Fixes the following bugs: #1025, #1044, #1059, #1089, #1097 as well as #1080 (uses `BlueprintService.newReward` to get the correct amount of returned FPs)

Known issues:
- when there are no 5-fp packs in the inventory and the player receives a new 5-fp pack from a (recurring) quest, the new pack will not be counted. It is added to the inventory and it will be correctly counted when the inventory updates. Unfortunately, the `InventoryService.getItem` is not triggered for the reward collection, so there seems to be no way to correctly initialize the inventory (we don't know that we've received a 5-fp pack because there is no matching item id in the inventory) 
Maybe we could guess, i.e. if the 10-fp and 2-fp packs are in the inventory and we add an unlabeled fp pack with an id different than the other two (10-fp and 2-fp packs) we could guess that a 5-fp pack has been added. But  that would work only iff the fp pack ids don't change, but I've seen them change occasionally