### PR TITLE
Inventory tracker (strategy points bar) update

### DIFF
--- a/js/web/inventory-tracker/js/inventory-tracker.js
+++ b/js/web/inventory-tracker/js/inventory-tracker.js
@@ -15,17 +15,17 @@ InventoryTracker = function(){
 
     // private
     let tmp = {
-        debug: false,
+        debug: true,
         aux: {
-            addInventoryAmount: (id, amount) => {
-
-                if ( !tmp.inventory[id] ){
-                    tmp.aux.setInventoryAmount(id, amount);
+            decomposeReward: ( value ) => {
+                let fp2s = 0, fp5s = 0;
+                if ( value % 2 == 1 ){ fp5s++; value -= 5;}
+                while ( value % 10 != 0 ){
+                    fp2s++;
+                    value -= 2;
                 }
-                let old = tmp.new.get(id);
-                let newAmount = tmp.inventory[id].inStock + amount - old;
-                tmp.new.set(id, amount);
-                tmp.aux.setInventoryAmount(id, newAmount);
+                let fp10s = value / 10;
+                return [fp2s, fp5s, fp10s];
             },
             getInventoryFp: () => {
                 let total = 0;
@@ -57,25 +57,18 @@ InventoryTracker = function(){
                 if ( tmp.initialized ){ return; }
                 tmp.initialized = true;
             },
-            indicators: {
-                load: (data) => {
-                    for( var i = 0; i < data.length; i++ ){
-                        let item = data[i];
-                        tmp.new.set( item['itemId'], item['amount'] );
-                    }
-                    tmp.new.initialized = true;
-                },
-            },
             inventory: {
                 addItem: (data) => {
                     if( !data['id'] ){ return; }
 
-                    data.inStock = 0;
-                    data.new = 0;
+                    data.inStock = data.inStock | 0;
+                    data.new = data.new | 0;
                     tmp.inventory[data['id']] = data;
+
+                    tmp.fp.total = tmp.aux.getInventoryFp();
+                    tmp.updateFpStockPanel();
                 },
                 resetNew: () => {
-                    tmp.new.reset();
                     for ( let [id, item] of Object.entries( tmp.inventory ) ){
                         tmp.inventory[id].new = 0;
                     }
@@ -104,19 +97,6 @@ InventoryTracker = function(){
                     tmp.fp.total = tmp.aux.getInventoryFp();
                     tmp.updateFpStockPanel();
                 },
-                updateRewards: (data) => {
-                    if ( !data ){ return };
-                    for ( var i = 0; i < data.length; i++ ){
-                        let item = data[i];
-                        let id = item['itemId'];
-                        let value = item['amount'];
-                        if ( id && value ) {
-                            tmp.aux.addInventoryAmount( id, value );
-                        }
-                    }
-                    tmp.fp.total = tmp.aux.getInventoryFp();
-                    tmp.updateFpStockPanel();
-                },
             },
         },
         fp: {
@@ -125,17 +105,18 @@ InventoryTracker = function(){
         handlers: {
             addInventoryHandlers: () => {
 
+                // an item which is not yet in the inventory is received
+                FoEproxy.addHandler('InventoryService', 'getItem', (data, postData) => {
+                    tmp.log('InventoryService.getItem');
+                    tmp.log( data.responseData );
+                    if( data.responseData ){
+                        tmp.action.inventory.addItem( data.responseData );
+                    }
+                });
+
                 FoEproxy.addHandler('InventoryService', 'getItems', (data, postData) => {
                     tmp.action.init();
                     tmp.log('InventoryService.getItems');
-                    tmp.log(data.responseData);
-                    tmp.action.inventory.set(data.responseData);
-                    // load new values
-                    tmp.new.init();
-                });
-
-                FoEproxy.addHandler('InventoryService', 'getItemsByType', (data, postData) => {
-                    tmp.log('InventoryService.getItemsByType');
                     tmp.log(data.responseData);
                     tmp.action.inventory.set(data.responseData);
                 });
@@ -159,11 +140,7 @@ InventoryTracker = function(){
                     tmp.log(data.responseData);
                     tmp.action.inventory.resetNew();
                 });
-                FoEproxy.addHandler('NoticeIndicatorService', 'getPlayerNoticeIndicators', (data, postData) => {
-                    tmp.log('NoticeIndicatorService.getPlayerNoticeIndicators');
-                    tmp.log(data.responseData);
-                    tmp.action.indicators.load(data.responseData);
-                });
+
             },
             addRawHandlers: () => {
 
@@ -171,18 +148,19 @@ InventoryTracker = function(){
                     if ( !data || !data[0] ){ return; }
                     let requestClass = data[0].requestClass;
                     let requestMethod = data[0].requestMethod;
-                    if ( requestClass == 'NoticeIndicatorService' && requestMethod == 'getPlayerNoticeIndicators' ){
-                        tmp.log( 'NoticeIndicatorService.getPlayerNoticeIndicators' );
-                        tmp.log( data[0].responseData );
-                        if ( data[0].responseData ) {
-                            tmp.action.inventory.updateRewards( data[0].responseData );
-                        }
-                    }
+
                     if ( requestClass == 'InventoryService' && requestMethod == 'getItem' ){
-                        tmp.log('InventoryService.getItem');
+                        tmp.log('WS InventoryService.getItem');
                         tmp.log( data[0].responseData );
                         if( data[0].responseData ){
                             tmp.action.inventory.addItem( data[0].responseData );
+                        }
+                    }
+                    if ( requestClass == 'InventoryService' && requestMethod == 'getItemAmount' ){
+                        tmp.log('WS InventoryService.getItemAmount');
+                        tmp.log( data[0].responseData );
+                        if( data[0].responseData ){
+                            tmp.action.inventory.update( data[0].responseData );
                         }
                     }
                 });
@@ -191,23 +169,6 @@ InventoryTracker = function(){
         initialized: false,
         // keep a copy of the inventory while this is work-in-progress
         inventory: {},
-        new: {
-            initialized: false,
-            data: {},
-            get: (id) => {
-                return tmp.new.data[id] | 0;
-            },
-            init: () => {
-                if ( tmp.new.initialized ){ return; }
-                tmp.new.reset();
-            },
-            reset: () => {
-                tmp.new.data = {};
-            },
-            set: (id, value) => {
-                tmp.new.data[id] = value;
-            },
-        },
         updateFpStockPanel: () => {
             StrategyPoints.RefreshBar( tmp.fp.total );
             tmp.log(`Set ForgePointBar: ${tmp.fp.total} `);
@@ -224,7 +185,7 @@ InventoryTracker = function(){
             return {
                 fp: tmp.fp.total,
                 inventory: tmp.inventory,
-                new: tmp.new.data,
+                // new: tmp.new.data,
             }
         },
         init: () => {

--- a/js/web/inventory-tracker/js/inventory-tracker.js
+++ b/js/web/inventory-tracker/js/inventory-tracker.js
@@ -1,18 +1,5 @@
 InventoryTracker = function(){
 
-    // Known issues:
-    //  - when there are no 5-fp packs in the inventory and the player receives a new 5-fp pack
-    //  from a (recurring) quest, the new pack will not be counted. It is added to the inventory
-    //  and it will be correctly counted when the inventory updates.
-    //  Unfortunately, the InventoryService.getItem is not triggered for the reward collection, so there
-    //  is no way to correctly initialize the inventory (we don't know that we've received a 5-fp pack
-    //  because there is no matching item id in the inventory)
-    //  Maybe we could guess, i.e. if the 10-fp and 2-fp packs are in the inventory and we add an unlabeled
-    //  fp pack with an id different than the other two (10-fp and 2-fp packs) we could guess that a 5-fp
-    //  pack has been added
-    //  - the above (guessing game) works only if the fp pack ids don't change, but I've seen them change
-    //  occasionally
-
     // private
     let tmp = {
         debug: false,

--- a/js/web/inventory-tracker/js/inventory-tracker.js
+++ b/js/web/inventory-tracker/js/inventory-tracker.js
@@ -15,18 +15,8 @@ InventoryTracker = function(){
 
     // private
     let tmp = {
-        debug: true,
+        debug: false,
         aux: {
-            decomposeReward: ( value ) => {
-                let fp2s = 0, fp5s = 0;
-                if ( value % 2 == 1 ){ fp5s++; value -= 5;}
-                while ( value % 10 != 0 ){
-                    fp2s++;
-                    value -= 2;
-                }
-                let fp10s = value / 10;
-                return [fp2s, fp5s, fp10s];
-            },
             getInventoryFp: () => {
                 let total = 0;
 

--- a/js/web/strategy-points/js/strategy-points.js
+++ b/js/web/strategy-points/js/strategy-points.js
@@ -79,22 +79,24 @@ let StrategyPoints = {
 		if ( isNaN( value ) ){ return; }
 		StrategyPoints.InventoryFP = value;
 
+		let delimiter = Number(1000).toLocaleString().substring(1,2);
+
 		// the animation function checks if start_value != end_value
 		$('.fp-storage').easy_number_animate({
 			start_value: StrategyPoints.OldStrategyPoints,
 			end_value: StrategyPoints.InventoryFP,
+            delimiter: delimiter,
 			duration: 750,
 			after: (el, val) => {
 				// this seems to be necessary due to a bug with the easy_number_animate
 				// jQuery plugin = if many animations run in a quick succession the order
 				// in which they finish is not guaranteed!
-				el.text(StrategyPoints.InventoryFP);
+				el.text( HTML.Format( StrategyPoints.InventoryFP ) );
 			}
 		});
 
 		StrategyPoints.OldStrategyPoints = StrategyPoints.InventoryFP;
 	},
-
 
 	/**
 	 * Liefert die gesamt verfügbaren FP

--- a/js/web/strategy-points/js/strategy-points.js
+++ b/js/web/strategy-points/js/strategy-points.js
@@ -50,10 +50,10 @@ let StrategyPoints = {
 			currentlyCosts += factor;
 		}
 
-    	for(let money = ResourceStock.money; money >= currentlyCosts; money--) {
-    		currentlyCosts += factor;
+		for(let money = ResourceStock.money; money >= currentlyCosts; money--) {
+			currentlyCosts += factor;
 			money -= currentlyCosts;
-    		amount++;
+			amount++;
 		}
 
 		if($('.buyable-fp').length == 0) {
@@ -85,7 +85,7 @@ let StrategyPoints = {
 		$('.fp-storage').easy_number_animate({
 			start_value: StrategyPoints.OldStrategyPoints,
 			end_value: StrategyPoints.InventoryFP,
-            delimiter: delimiter,
+			delimiter: delimiter,
 			duration: 750,
 			after: (el, val) => {
 				// this seems to be necessary due to a bug with the easy_number_animate


### PR DESCRIPTION
- Fixed the issue with adding packs to the inventory when the inventory does not already have packs of that type 
- Fixed the number format of the 'strategy points' text (uses number to locale string now)

- Properly implemented `InvetoryService` (both JSON and raw WS listeners)
- Removed reliance on (buggy) `NoticeIndicatorService` 
- Discontinued keeping track of new packs (there's no need now)

ref: #1059