### PR TITLE
Fehlerbehebung Notizen

### DIFF
--- a/js/web/notice/css/notice.css
+++ b/js/web/notice/css/notice.css
@@ -15,7 +15,7 @@
 #notices {
 	left: calc(50% - 200px);
 	top: 30%;
-	min-width: 400px;
+	min-width: 500px;
 }
 
 #noticesBody {


### PR DESCRIPTION
Die `min-width` war beim `noticesBody` größer als beim übergeordneten Element `notices`, was folgenden Fehler verursachte
![grafik](https://user-images.githubusercontent.com/47282153/86516849-560cc900-be24-11ea-8b00-11f6186c386c.png)
