### PR TITLE
Fehlerbehebung Statistik

### DIFF
--- a/js/web/technologies/js/technologies.js
+++ b/js/web/technologies/js/technologies.js
@@ -105,7 +105,7 @@ let Technologies = {
         3: 'IronAge',
         4: 'EarlyMiddleAge',
         5: 'HighMiddleAge',
-        6: 'LateMiddleAge ',
+        6: 'LateMiddleAge',
         7: 'ColonialAge',
         8: 'IndustrialAge',
         9: 'ProgressiveEra',


### PR DESCRIPTION
Dieses Leerzeichen hat (unter Anderem) bei den Statistiken zu Bugs geführt, beispielweise funktionierte der "Aktuelles"-Button bei der Zeitalterasuwahl nicht (betrifft Spieler im späten Mittelalter)
![grafik](https://user-images.githubusercontent.com/47282153/86530945-750b6980-bebd-11ea-9bfe-9601a8803fb1.png)
![grafik](https://user-images.githubusercontent.com/47282153/86530946-7fc5fe80-bebd-11ea-9612-763448a42641.png)
