### PR TITLE
Investment Menu OpenClose Fix

### DIFF
--- a/js/web/_menu/js/_menu.js
+++ b/js/web/_menu/js/_menu.js
@@ -734,7 +734,7 @@ let _menu = {
 		let btn_Investment = $('<span />');
 
 		btn_Investment.on('click', function () {
-			Investment.BuildBox();
+			Investment.BuildBox(false);
 		});
 
 		btn_InvestH.append(btn_Investment);

--- a/js/web/investment/js/investment.js
+++ b/js/web/investment/js/investment.js
@@ -19,7 +19,7 @@ FoEproxy.addHandler('GreatBuildingsService', 'getContributions', (data) => {
 
     Investment.UpdateData(Investment.Data, true).then((e) => {
         if (Settings.GetSetting('ShowInvestments')){
-            Investment.BuildBox();
+            Investment.BuildBox(true);
         }
     });
 
@@ -33,7 +33,7 @@ let Investment = {
     Ertrag: 0,
 
 
-    BuildBox: ()=> {
+    BuildBox: (event)=> {
         if ($('#Investment').length === 0) {
             HTML.Box({
                 id: 'Investment',
@@ -47,7 +47,7 @@ let Investment = {
 
             HTML.AddCssFile('investment');
         }
-        else {
+        else if(!event) {
             HTML.CloseOpenBox('Investment');
             return;
         }


### PR DESCRIPTION
Investment Overview didn't close when an event trigger BuildBox()