### PR TITLE
Blue Galaxy tab includes large FP package resource

### DIFF
--- a/js/web/bluegalaxy/js/bluegalaxy.js
+++ b/js/web/bluegalaxy/js/bluegalaxy.js
@@ -165,6 +165,8 @@ let BlueGalaxy = {
                         GoodsSum += product.resources.amount;
                     else if (product.type == "genericReward" && product.resources?.type == "forgepoint_package")
                         FP += parseInt(product.resources.subType)
+                    else if (product.type == "genericReward" && product.resources?.id == "large_forgepoint_package_40")
+                        FP += 10 * parseInt(product.resources.amount)
 
                     if (product.type == "resources" || product.type == "guildResources")
                         for (let j = 0; j < GoodsList.length; j++) {


### PR DESCRIPTION
Momijidori Altar has a chance to produce 40x Large Forge Points Package, which are not reflected in the Blue Galaxy Helper tab.
This change includes them in the tab.
<img width="734" height="428" alt="BlueGalaxyMomijidori" src="https://github.com/user-attachments/assets/10c4e733-1f44-446c-8db8-30739491502f" />

