### PR TITLE
fix(profile): prevent double-counting FP and goods % for other players

### DIFF
--- a/js/web/profile/js/profile.js
+++ b/js/web/profile/js/profile.js
@@ -573,6 +573,8 @@ const Profile = {
             // gather boosts from efficiency ratings
             for (let [boost, value] of Object.entries(building.rating)) {
                 if (boost.includes('-tile')) continue;
+                // forge_points_production and goods_production are also gathered from building.boosts below — skip here to avoid double-counting
+                if (boost === 'forge_points_production' || boost === 'goods_production') continue;
                 if (boosts[boost] === undefined)
                     boosts[boost] = value;
                 else


### PR DESCRIPTION
In showOtherPlayer(), forge_points_production and goods_production were accumulated twice per building: once via building.rating (which already reads from building.boosts internally) and again directly from building.boosts, resulting in doubled percentages and wrong FP and Goods production values.