### PR TITLE
bugfix: Fix GB Calculator functionality

### DIFF
--- a/changelog-en.md
+++ b/changelog-en.md
@@ -1,6 +1,13 @@
 ## Changelog - Extension
 
 
+##### 4.2.2.0
+
+**Bugfix**
+- GB Cost Calculator (other players’ cities): The helper now listens for the game’s map-entity response when you open someone else’s great building, and it no longer drops half of the data when the server sends rankings and map info in separate replies. The calculator should show content again instead of staying blank.
+
+---
+
 ##### 4.2.1.0
 
 **Update**
@@ -35,12 +42,12 @@
 - Productions: Added a list for special productions
 - Settings: Removed some "open automatically" settings if they are already available in the modules windows settings
 - QI city: The title changes with the difficulty level now
-- Ownpart Calculator/GB Cost Calculator: the FP values can now be clicked - the value is written directly to the input field or at least copied to the clipboard	
+- Ownpart Calculator/GB Cost Calculator: the FP values can now be clicked - the value is written directly to the input field or at least copied to the clipboard
 - Ownpart Calculator: added an Option to in-/exclude initial FP in given sum values
 
 **Bugfix**
 - Copy city data: data format was slightly off by accident, works like before now
-- Allies: 
+- Allies:
 	- The sums weren't correct and boosts were *slightly* off after leveling allies
 	- A freshly assembled Ally was listed twice, when the amount of fragments was exactly 0 after assembly
 	- the Box did not close when already open upon menu click
@@ -54,11 +61,11 @@
 - Reconstruction mode: there is now a map that updates live. You can access it via a button in the reconstruction list
 
 **Update**
-- City Map: 
+- City Map:
 	- Sidebar stats have been reworked: more interesting facts about buildings in the city were added
 	- Filters have been revamped and are now in the bottom area of the sidebar (you will find them if you look hard enough)
 	- Available area for other players cities has been added
-- Profile: 
+- Profile:
 	- QI capacity added
 	- The mini icon on the top left corner blocked the ingame research button, so it was moved a bit
 	- Main part can now be selected and copied, so you can share your most impartant stats ingame more easily
@@ -80,7 +87,7 @@
 ##### 4.0.2.0
 
 **Update**
-- Efficiency: 
+- Efficiency:
 	- Changed default values
 	- When the option "show ascended/limited buildings" is active, lines with such buildings in your city will not show the inventory checkmark anymore
 - Ally Boosts: Adapted to changed data transmission
@@ -100,7 +107,7 @@
 	- as the server time is not transmitted consistently, server offset can now be set manually
 - General
 	- further improvements for loading behavior
-	
+
 ---
 
 ##### 4.0.0.0
@@ -116,11 +123,11 @@
  	- Unlock times are now converted to server time when copied
 	- To also display the unlock-times in server time, check the settings
 - Player Links
-	- you can now select between foestats.com and scoredb.io in the main settings 
+	- you can now select between foestats.com and scoredb.io in the main settings
 - Shop Assistant
 	- Column "Missing" now always gives the amount until the next complete set
 - Settlements
-	- Added goods for pirate settlement 
+	- Added goods for pirate settlement
 - Player profiles:
 	- Now available for other players: visit them and click in the top left corner
 
@@ -224,8 +231,8 @@
 	- locked offers can be hidden from the list
 	- an alert can be set for offers - it will go off when enough currency is available to buy the offer
 
-**Update** 
-- Helper design was reworked in some places 
+**Update**
+- Helper design was reworked in some places
 	- boxes are now limited in size to browser window size
 
 - Efficiency overview
@@ -248,7 +255,7 @@
 	- reactivated
 
 - Army Advice
-	- can now be used as well in PvP Arena 
+	- can now be used as well in PvP Arena
 
 **Bugfix**
 - Popgame
@@ -280,7 +287,7 @@
 	- Chain buildings with Era-dependent values are now properly evaluated
 
 - QI action points calculator:
-	- capacity increase should now be handled 
+	- capacity increase should now be handled
 
 - Guild member overview:
 	- added guild goods production to export
@@ -408,7 +415,7 @@
 
 **New**
 - Player Profile
-	- After opening the profile, an icon to show the player profile will appear next to your city name 
+	- After opening the profile, an icon to show the player profile will appear next to your city name
 - Settings
 	- Disable QI and GBG pop ups
 - Ally Overview
@@ -442,7 +449,7 @@
 
 **BugFix**
 - Alerts still did not work
-- Efficiency 
+- Efficiency
 	- fix count for buildings with allies
 - Market Overview
 	- filter overlapped by table header
@@ -473,12 +480,12 @@
 
 **Update**
 - Tooltip: made design similar to original FoE tooltips
-- Building Efficiency: 
+- Building Efficiency:
 	- Added building tooltips
 	- Results will now be shown first
 	- Item list hidden to make the table less crowded
 - Menu: Moved it back to the right (default was bottom), because of a game update and y'all do not look at settings
-- GBG: 
+- GBG:
 	- Added symbols for the battle type (red/blue) to the countdown list
 	- Added attack colors to the map
 	- Added map view to highlight attack colors better
@@ -486,10 +493,10 @@
 	- removed the module on Innos request
 
 **BugFix**
-- Tooltip: 
+- Tooltip:
 	- Some browsers did not use the correct design
 	- Did sometimes not vanish when a box was closed
-- Reconstruction List: 
+- Reconstruction List:
 	- Set a default height
 	- Moving buildings reduced counter
 - Building Efficiency:
@@ -511,7 +518,7 @@
 - Changed settings entry "Load current beta"
 
 **BugFix**
-- Building efficiency: 
+- Building efficiency:
 	- Broke for some players due to a game update
 	- Same buildings with/without allies were not counted correctly
 - Porduction Overview:
@@ -684,7 +691,7 @@
 - Settlements:
 	- added images for polynesia
 - GvG:
-	removed the module	
+	removed the module
 - FP Bar:
 	- moved it to the left in QI
 	- now also shows in the main city when more than 999 FP in bar
@@ -791,7 +798,7 @@
 ##### 3.5.0.1
 **Update**
 - City Map
-	- Better visibility for highlighted buildings 
+	- Better visibility for highlighted buildings
 	- Added highlighting for buildings that do not require streets
     - Added a global sorting layout
 
@@ -835,7 +842,7 @@
 
 **BugFix**
 - Moppelhelper:
-	- fix era sorting 
+	- fix era sorting
 
 - GBG
 	- some own provinces were not shown in the "locked" list
@@ -871,7 +878,7 @@
 **Update**
 - Sets/Kits:
 	- added buildings until Halloween 2023
-	
+
 - General:
 	- when a limited building expires, an Alert is triggert
 
@@ -912,7 +919,7 @@
 - Merger Game:
 	- added a daily overview - you can switch between current game status and daily status by clicking the second column head
 	- fixed blocker position
-	- An optioon was added to set a specific reset cost to be used instead of the correct one 
+	- An optioon was added to set a specific reset cost to be used instead of the correct one
 		- you should enter the average of the epected reset costs here (e.g.: 3 games per day --> 20, 4 games per day --> 35)
 		- this should help to improve the efficiency evaluation as they are not influenced by the reset costs anymore
 
@@ -924,7 +931,7 @@
 
 **BugFix**
 - Discord Invite links were broken, so we replaced them
-- 
+-
 ---
 ##### 3.2.5.0
 
@@ -952,7 +959,7 @@
 **BugFix**
 - Production Overview:
 	- FP Boost was applied to Great Buildings
-  
+
 - Idle Game:
 	- setting timers now works properly - limited to times below 24 hours
 
@@ -962,7 +969,7 @@
 **Update**
 - Idle Game:
 	- now also works with Fellowship event
-	- added Strategy-Tasklist 
+	- added Strategy-Tasklist
 		- if you like mooing cats strategy guides, this will help you to implement them without the need to permanently check the guide from another source
 		- the guide tasks can be added manually within the dialogue body and will be saved independently for every variation of run through. Format:
 			- ...Description Text...#condition1#condition2#condition3
@@ -1015,7 +1022,7 @@
 **BugFix**
 - external images:
 	- when the game file was not in cache, it could happen that images from Innogames were not loaded properly
-  
+
 - GB-Calculator:
 	- if the Infobox was open before the GB Calculator, it could happen that by clicking the filter in the Infobox, the settings of the GB Calculator were opened
 ---
@@ -1062,7 +1069,7 @@
 
 - FP-Collector:
 	- added Anniversary-Event
-	
+
 ---
 
 ##### 3.2.0.0
@@ -1076,7 +1083,7 @@
 	- added new Track (will be available on live latest with the anniversary event, currently only available on beta)
 
 - Event cost calculator:
-	- second cost column added to the right side of table 
+	- second cost column added to the right side of table
 	- highlighting of the most efficient option now also is in the respective cost column
 
 - Kits:

--- a/js/web/_main/js/_main.js
+++ b/js/web/_main/js/_main.js
@@ -718,6 +718,18 @@ GetFights = () =>{
 		if (Rankings) {
 			if (!lgUpdateData || !lgUpdateData.CityMapEntity) {
 				lgUpdateData = { Rankings: Rankings, CityMapEntity: null, Bonus: null };
+				// contributeForgePoints often returns rankings without CityMapService.updateEntity in the same reply.
+				// Refresh calculators from cached map data so FP/rank rows update immediately; a later updateEntity still merges via else branch.
+				if (contributeForgePoints != null && !IsLevelScroll) {
+					if ($('#costCalculator').length > 0 && Calculator.CityMapEntity !== undefined) {
+						Calculator.Rankings = Rankings;
+						Calculator.Show();
+					}
+					if ($('#OwnPartBox').length > 0 && Parts.CityMapEntity !== undefined) {
+						Parts.Rankings = Rankings;
+						Parts.CalcBody();
+					}
+				}
 			}
 			else {
 				lgUpdateData.Rankings = Rankings;

--- a/js/web/_main/js/_main.js
+++ b/js/web/_main/js/_main.js
@@ -721,7 +721,8 @@ GetFights = () =>{
 				// contributeForgePoints often returns rankings without CityMapService.updateEntity in the same reply.
 				// Refresh calculators from cached map data so FP/rank rows update immediately; a later updateEntity still merges via else branch.
 				if (contributeForgePoints != null && !IsLevelScroll) {
-					if ($('#costCalculator').length > 0 && Calculator.CityMapEntity !== undefined) {
+					// Only refresh the foreign-GB cost calculator; stale Calculator.CityMapEntity from a past visit must not get own-GB rankings.
+					if ($('#costCalculator').length > 0 && Calculator.CityMapEntity !== undefined && Calculator.CityMapEntity.player_id !== ExtPlayerID) {
 						Calculator.Rankings = Rankings;
 						Calculator.Show();
 					}

--- a/js/web/_main/js/_main.js
+++ b/js/web/_main/js/_main.js
@@ -38,9 +38,9 @@ let ExistenceConfirmed = async (varlist)=>{
 					break;
 				}
 			}
-			if (doResolve) 
+			if (doResolve)
 				resolve();
-			else 
+			else
 				setTimeout(timer, 100);
 		};
 		timer();
@@ -82,7 +82,7 @@ let ApiURL = 'https://api.foe-rechner.de/',
 	LGCurrentLevelMedals = undefined,
 	IsLevelScroll = false,
 	EventCountdown = false,
-	StartUpDone = new Promise(resolve => 
+	StartUpDone = new Promise(resolve =>
 			window.addEventListener('foe-helper#StartUpDone', resolve, {once: true, passive: true})),
 	Fights = [],
 	OwnUnits = [],
@@ -100,11 +100,11 @@ let GameTime = {
 	Offset: 0,
 	set:(time)=>{
 		GameTime.Offset = time-moment().unix();
-	},	
+	},
 	get:()=>{
 		return moment().unix()+GameTime.Offset;
 	}
-	
+
 
 }
 
@@ -142,8 +142,8 @@ const i18n_loadPromise = (async () => {
 		// warte dass i18n geladen ist
 		//console.log("await vendors loaded")
 		await vendorsLoadedPromise;
-		//console.log("vendors loaded");	
-		
+		//console.log("vendors loaded");
+
 		for (let languageData of languageDatas) {
 			i18n.translator.add({ 'values': JSON.parse(languageData) });
 		}
@@ -236,7 +236,7 @@ GetFights = () =>{
 	});
 	FoEproxy.addMetaHandler("building_families", (xhr,postData) => {
 		MainParser.BuildingFamilyLimits = JSON.parse(xhr.responseText)?.families;
-	})	
+	})
 	// Castle-System-Levels
 	FoEproxy.addMetaHandler('castle_system_levels', (xhr, postData) => {
 		MainParser.CastleSystemLevels = JSON.parse(xhr.responseText);
@@ -257,7 +257,7 @@ GetFights = () =>{
 
 	FoEproxy.addHandler('AllyService', 'getAllies', (data, postData) => {
 		MainParser.Allies.getAllies(data.responseData);
-		
+
 		if (!Settings.GetSetting('ShowAllyList')) return;
 		if (postData[0].requestMethod == 'getAllies') MainParser.Allies.showAllyList();
 	});
@@ -352,7 +352,7 @@ GetFights = () =>{
 		if (data.responseData.unlocked_features) {
 			MainParser.UnlockedFeatures = data.responseData.unlocked_features?.map(function(obj) { return obj.feature; });
 		} else {
-			$('script').each((i,s)=>{    
+			$('script').each((i,s)=>{
 				if (!s?.innerHTML?.includes("unlockedFeatures")) return
 				try {
 					let ulf = JSON.parse([...s.innerHTML.matchAll(/(unlockedFeatures:\ )(.*?)(,\n)/gm)][0][2])
@@ -365,7 +365,7 @@ GetFights = () =>{
 
 		//A/B Tests
 		MainParser.ABTests=Object.assign({}, ...data.responseData.active_ab_tests.map((x) => ({ [x.test_name]: x })));
-	
+
 		Stats.Init();
 		Alerts.init();
 	});
@@ -398,7 +398,7 @@ GetFights = () =>{
 	});
 
 	// QI map
-	FoEproxy.addHandler('GuildRaidsMapService', 'getOverview', (data, postData) => {		
+	FoEproxy.addHandler('GuildRaidsMapService', 'getOverview', (data, postData) => {
 		QIMap.init(data.responseData)
 	})
 
@@ -429,7 +429,7 @@ GetFights = () =>{
 
 	// Stadt wird wieder aufgerufen
 	FoEproxy.addHandler('CityMapService', 'getEntities', (data, postData) => {
-		if (!postData.map(x=>x.requestData?.[0]).includes('main')) { 
+		if (!postData.map(x=>x.requestData?.[0]).includes('main')) {
 			return;
 		}
 
@@ -631,11 +631,11 @@ GetFights = () =>{
 			MainParser.UpdatePlayerDict(data.responseData, 'PlayerList', data.requestMethod);
 		}
 		if (data.requestMethod === 'getSocialList') {
-			if (data.responseData.neighbours) 
+			if (data.responseData.neighbours)
 				MainParser.UpdatePlayerDict(data.responseData.neighbours, 'PlayerList', 'getNeighborList');
-			if (data.responseData.guildMembers) 
+			if (data.responseData.guildMembers)
 				MainParser.UpdatePlayerDict(data.responseData.guildMembers, 'PlayerList', 'getClanMemberList');
-			if (data.responseData.friends) 
+			if (data.responseData.friends)
 				MainParser.UpdatePlayerDict(data.responseData.friends, 'PlayerList', 'getFriendsList');
 		}
 	});
@@ -718,8 +718,6 @@ GetFights = () =>{
 		if (Rankings) {
 			if (!lgUpdateData || !lgUpdateData.CityMapEntity) {
 				lgUpdateData = { Rankings: Rankings, CityMapEntity: null, Bonus: null };
-				// reset lgUpdateData so bald wie möglich (nachdem alle einzelnen Handler ausgeführt wurden)
-				Promise.resolve().then(() => lgUpdateData = null);
 			}
 			else {
 				lgUpdateData.Rankings = Rankings;
@@ -742,19 +740,26 @@ GetFights = () =>{
 	FoEproxy.addHandler('CityMapService', 'updateEntity', (data, postData) => {
 		if (!lgUpdateData || !lgUpdateData.Rankings) {
 			lgUpdateData = { Rankings: null, CityMapEntity: data };
-			// reset lgUpdateData sobald wie möglich (nachdem alle einzelnen Handler ausgeführt wurden)
-			Promise.resolve().then(() => lgUpdateData = null);
 		} else {
 			lgUpdateData.CityMapEntity = data;
 			lgUpdate();
 		}
-		
+
 		if (data.responseData[0]?.player_id === ExtPlayerID) {
-			
+
 			if ($('#OwnPartBox').length > 0) {
 				Parts.CityMapEntity.max_level = data.responseData[0]?.max_level;
 				Parts.CalcBody();
 			}
+		}
+	});
+
+	FoEproxy.addHandler('OtherPlayerService', 'getOtherPlayerCityMapEntity', (data, postData) => {
+		if (!lgUpdateData || !lgUpdateData.Rankings) {
+			lgUpdateData = { Rankings: null, CityMapEntity: data };
+		} else {
+			lgUpdateData.CityMapEntity = data;
+			lgUpdate();
 		}
 	});
 
@@ -790,8 +795,11 @@ GetFights = () =>{
 
 		if (!Rankings) return; //Keine Rankings => Fehlermeldung z.B. "Stufe wurde bereits erhöht" wenn man versucht einzuzahlen obwohl schon gelevelt wurde
 
+		const entityData = getCityMapEntityFromResponse(CityMapEntity.responseData);
+		if (!entityData) return;
+
 		//Eigenes LG
-		if (CityMapEntity.responseData[0].player_id === ExtPlayerID || Settings.GetSetting('ShowOwnPartOnAllGBs')) {
+		if (entityData.player_id === ExtPlayerID || Settings.GetSetting('ShowOwnPartOnAllGBs')) {
 			//LG Scrollaktion: Beim ersten mal Öffnen Medals von P1 notieren. Wenn gescrollt wird und P1 weniger Medals hat, dann vorheriges Level, sonst aktuelles Level
 			if (IsLevelScroll) {
 				let Medals = 0;
@@ -817,7 +825,7 @@ GetFights = () =>{
 				LGCurrentLevelMedals = Medals;
 			}
 
-			Parts.CityMapEntity = CityMapEntity.responseData[0];
+			Parts.CityMapEntity = entityData;
 			Parts.Rankings = Rankings;
 			Parts.IsPreviousLevel = IsPreviousLevel;
 
@@ -831,13 +839,13 @@ GetFights = () =>{
 		}
 
 		// Fremdes LG
-		if (CityMapEntity.responseData[0].player_id !== ExtPlayerID && !IsLevelScroll)
+		if (entityData.player_id !== ExtPlayerID && !IsLevelScroll)
 		{
 			$('#calculator-Btn').removeClass('hud-btn-red');
 			$('#calculator-Btn-closed').remove();
 
 			Calculator.Rankings = Rankings;
-			Calculator.CityMapEntity = CityMapEntity['responseData'][0];
+			Calculator.CityMapEntity = entityData;
 
 			// wenn schon offen, den Inhalt updaten
 			if ($('#costCalculator').length > 0) {
@@ -880,16 +888,16 @@ GetFights = () =>{
 		GameTime.set(data.responseData.time);
 		if (MainMenuLoaded) return;
 
-	
+
 		MainMenuLoaded = true;
-		await StartUpDone;	
+		await StartUpDone;
 		let MenuSetting = localStorage.getItem('SelectedMenu');
 		MainParser.SelectedMenu = MenuSetting || 'RightBar';
 		_menu.CallSelectedMenu(MainParser.SelectedMenu);
-		
+
 		MainParser.setLanguage();
 
-		Quests.init();	
+		Quests.init();
 	});
 
 
@@ -907,7 +915,7 @@ GetFights = () =>{
 			ResourceStock[responseData.need.good_id] += responseData.need.value;
 			FoEproxy.triggerFoeHelperHandler("ResourcesUpdated");
 		}
-		// Inventory Update, e.g. when receiving FP packages from GB leveling	
+		// Inventory Update, e.g. when receiving FP packages from GB leveling
 		if (requestClass === 'InventoryService' && requestMethod === 'getItem') {
 			MainParser.UpdateInventoryItem(responseData);
 		}
@@ -959,6 +967,20 @@ GetFights = () =>{
 
 })();
 
+/**
+ * CityMapService.updateEntity uses responseData as an array; OtherPlayerService.getOtherPlayerCityMapEntity
+ * may return one entity or a city map with an entities[] list.
+ */
+function getCityMapEntityFromResponse(responseData) {
+	if (responseData == null) return undefined;
+	if (Array.isArray(responseData)) return responseData[0];
+	if (responseData.entities && Array.isArray(responseData.entities)) {
+		const gb = responseData.entities.find(e => e && e.type === 'greatbuilding');
+		return gb || responseData.entities[0];
+	}
+	return responseData;
+}
+
 let HelperBeta = {
 	load: (active) => {
 		if (active !== false) active = true;
@@ -1009,9 +1031,9 @@ let MainParser = {
 	BuildingSets: null,
 	BuildingChains: null,
 	SelectionKits: null,
-	
+
 	BuildingFamilyLimits: null,
-	
+
 	InnoCDN: 'https://foede.innogamescdn.com/',
 
 	/**
@@ -1330,7 +1352,7 @@ let MainParser = {
 			return HTML.escapeHtml(PlayerName);
 		}
 	},
-	
+
 	/**
 	 * @param GuildID
 	 * @param GuildName
@@ -1475,11 +1497,11 @@ let MainParser = {
 
 		ExtPlayerAvatar = d.portrait_id;
 		await ExistenceConfirmed('MainParser.CityEntities||srcLinks.FileList||Infoboard||EventHandler');
-	
+
 		Infoboard.Init();
 		EventHandler.Init();
 		setTimeout(MainParser.forceLoadCityEntities, 15000);
-	
+
 		window.dispatchEvent(new CustomEvent('foe-helper#StartUpDone'))
 		//console.log('StartUp done')
 	},
@@ -1529,7 +1551,7 @@ let MainParser = {
 	 */
 	SendLGData: (d)=> {
 
-		const dataEntity = d['CityMapEntity']['responseData'][0],
+		const dataEntity = getCityMapEntityFromResponse(d['CityMapEntity']['responseData']),
 			realData = {
 				image: srcLinks.get(`/city/buildings/${dataEntity['cityentity_id'].replace('X_', 'X_SS_')}.png`, true),
 				entity: dataEntity,
@@ -1558,9 +1580,9 @@ let MainParser = {
 			let list = MainParser.Allies.buildingList = {}
 			for (let ally of allies) {
 				if (!ally.mapEntityId) continue
-				if (list[ally.mapEntityId]) 
+				if (list[ally.mapEntityId])
 					list[ally.mapEntityId][ally.id]=ally.id
-				else 
+				else
 				 	list[ally.mapEntityId] = {[ally.id]:ally.id}
 			}
 			MainParser.Allies.updateAllyList()
@@ -1569,9 +1591,9 @@ let MainParser = {
 		updateAlly:(ally)=>{
 			if (ally.mapEntityId) {
 				let list = MainParser.Allies.buildingList
-				if (list[ally.mapEntityId]) 
+				if (list[ally.mapEntityId])
 					list[ally.mapEntityId][ally.id]=ally.id
-				else 
+				else
 				 	list[ally.mapEntityId] = {[ally.id]:ally.id}
 			} else {
 				mapID=MainParser.Allies.allyList[ally.id]?.mapEntityId
@@ -1590,7 +1612,7 @@ let MainParser = {
 		},
 
 		setMeta:(raw)=>{
-			let meta = MainParser.Allies.meta = {} 
+			let meta = MainParser.Allies.meta = {}
 			for (ally of raw) {
 				meta[ally.id]=ally
 			}
@@ -1630,7 +1652,7 @@ let MainParser = {
 		},
 
 		showAllyList:(closeIfOpen = false)=>{
-			
+
 			//console.log(0, MainParser.Allies);
 
 			if ($('#AllyList').length === 0) {
@@ -1643,7 +1665,7 @@ let MainParser = {
 					minimize: true,
 					resize: true,
 					settings: 'MainParser.Allies.ShowSettings()',
-					active_maps:"main",				
+					active_maps:"main",
 				});
 			} else {
 				if (closeIfOpen) {
@@ -1655,7 +1677,7 @@ let MainParser = {
 		},
 
 		updateAllyList:()=>{
-			MainParser.Allies.buildingBoostSums=[]	
+			MainParser.Allies.buildingBoostSums=[]
 			if ($('#AllyList').length === 0) return;
 			let buildings = Object.assign({},...Object.values(MainParser.CityMapData).map(x=>({id:x.id,metaID:x.cityentity_id,rooms:structuredClone(MainParser.CityEntities[x.cityentity_id]?.components?.AllAge?.ally?.rooms)})).filter(x=>x.rooms!==undefined).map(x=>({[x.id]:x})))
 			let rooms = {}
@@ -1677,7 +1699,7 @@ let MainParser = {
 				} else {
 					rooms[0+"#" + unassigned] = {
 						allyRarity: x.rarity?.value || "",
-						allyLevel: x.level || null,												
+						allyLevel: x.level || null,
 						allyBoosts: x.currentLevel?.boosts || x.boosts || null,
 						allyName: MainParser.Allies.meta[x.allyId]?.name || "",
 					}
@@ -1691,7 +1713,7 @@ let MainParser = {
 						buildingMeta:b.metaID,
 						roomRarity: r.rarity?.value || Object.keys(MainParser.Allies.rarities).join("#"),
 						allyRarity: r.ally?.rarity?.value || "",
-						allyLevel: r.ally?.level || null,												
+						allyLevel: r.ally?.level || null,
 						allyBoosts: r.ally?.currentLevel?.boosts || r.ally?.boosts || null,
 						allyName: MainParser.Allies.meta[r.ally?.allyId]?.name || "",
 					}
@@ -1703,7 +1725,7 @@ let MainParser = {
 					fragmentsAmount: x.inStock,
 					fragmentsNeeded: x.item.reward.requiredAmount,
 					allyRarity: x.item.reward.assembledReward.rarity?.value || "",
-					allyLevel: x.item.reward.assembledReward.level || null,												
+					allyLevel: x.item.reward.assembledReward.level || null,
 					allyBoosts: x.item.reward.assembledReward.boosts || null,
 					allyName: x.item.reward.assembledReward.name,
 				}
@@ -1726,7 +1748,7 @@ let MainParser = {
 				f=(r)=>{return Object.keys(MainParser.Allies.rarities).indexOf(r.allyRarity) + (r.buildingName?10:0) + (r.fragmentsAmount?100:0)}
 				return f(a[1])-f(b[1])
 			})
-				
+
 			for (let [roomId,r] of sortedRooms){
 				let buildingId=roomId.split("#")[0]
 				let rarities=r.roomRarity?.split("#")||[]
@@ -1736,10 +1758,10 @@ let MainParser = {
 				//${MainParser.Allies.tooltip(buildingId)}
 				html+=`<tr class="allyRoomRow ${rarities.join(" ")}">
 							<td style="white-space:nowrap">${MainParser.Allies.rarityStars(r.roomRarity)}</td>
-					   	   	<td ${buildingId!=0?`class="helperTT" 
-								data-id="${buildingId}" 
+					   	   	<td ${buildingId!=0?`class="helperTT"
+								data-id="${buildingId}"
 								data-era="${Technologies.InnoEraNames[MainParser.CityMapData[buildingId].level]}"
-								data-callback_tt="Tooltips.buildingTT" 
+								data-callback_tt="Tooltips.buildingTT"
 								`:``}
 							>${r.buildingName || ""}</td>
 							<td>${buildingId!=0?`<span class="show-entity" data-id="${buildingId}"><img class="game-cursor" src="${ extUrl + 'css/images/hud/open-eye.png'}"></span>`:""}</td>
@@ -1773,7 +1795,7 @@ let MainParser = {
 			html+=`<tr><td colspan="7" class="text-center dark-bg">
 				${MainParser.Allies.boosts(MainParser.Allies.buildingBoostSums)}
 				</td></tr></table>`
-			
+
 			$('#AllyListBody').html(html).css("overflow","auto")
 
 			$('#AllyFilter').on("change",()=>{
@@ -1793,7 +1815,7 @@ let MainParser = {
 			let i = Object.keys(MainParser.Allies.rarities).indexOf(r)
 			if (i==-1) return `<img style="filter: drop-shadow(0px 2px 2px black)"  src="${srcLinks.get(`/shared/icons/when_motivated.png`, true)}">`
 			if (i==0) return `<span style="font-size: large; color: transparent; text-shadow: 0px 0px 4px black;" >☆</span>`
-			let ret=""					
+			let ret=""
 			let star = `<img style="margin-left:-3px"  src="${srcLinks.get(`/historical_allies/portraits/historical_allies_portrait_rarity_icon.png`, true)}">`
 			for (let j = 0; j < i; j++) {
 				ret += star
@@ -1801,7 +1823,7 @@ let MainParser = {
 			}
 			return ret
 		},
-				
+
 		boosts: (boosts) => {
 			let feature = {
 				"all":"",
@@ -1831,7 +1853,7 @@ let MainParser = {
 			if ($("#allyListAutoOpen").is(':checked'))
 				value = true;
 			localStorage.setItem('ShowAllyList', value);
-			
+
 			$(`#AllyListSettingsBox`).remove();
 		},
 
@@ -2054,7 +2076,7 @@ let MainParser = {
 			let ID = Buildings[i]['id'];
 			if (MainParser.CityMapData[ID]) {
 				MainParser.CityMapData[ID] = Buildings[i];
-			} 
+			}
 			if (ActiveMap === "era_outpost") {
 				CityMap.EraOutpost.data[ID] = Buildings[i];
 			}
@@ -2262,7 +2284,7 @@ let MainParser = {
 				}
 			}
 			MainParser.Inactives.list = [...new Set(list.map(x=>MainParser.CityMapData[x].cityentity_id))];
-			
+
 			//remove tracked buildings if time ran out
 			for (let x in LB) {
 				if (!LB[x]) continue;
@@ -2272,7 +2294,7 @@ let MainParser = {
 			if(!Settings.GetSetting('ShowBuildingsExpired')){
 				return;
 			}
-			//create instant alert for currently expired buildings		
+			//create instant alert for currently expired buildings
 			if (list.length > 0) {
 					const data = {
 					title: i18n("InactiveBuildingsAlert.title"),
@@ -2285,7 +2307,7 @@ let MainParser = {
 					vibrate: false,
 					actions: [{title:"OK"}]
 				};
-		
+
 				MainParser.sendExtMessage({
 					type: 'alerts',
 					playerId: ExtPlayerID,
@@ -2308,7 +2330,7 @@ let MainParser = {
 						vibrate: false,
 						actions: [{title:"OK"}]
 					};
-			
+
 					MainParser.sendExtMessage({
 						type: 'alerts',
 						playerId: ExtPlayerID,
@@ -2334,13 +2356,13 @@ let MainParser = {
 					minimize: true,
 					resize: true,
 				});
-	
+
 				//HTML.AddCssFile('auctions');
 			}
 			MainParser.Inactives.updateSettings();
 		},
 
-		updateSettings:()=>{ 
+		updateSettings:()=>{
 			let t=[];
 			//t.push(`<h2>${i18n('Boxes.InactivesSettings.Ignored')}</h2>`);
 			t.push(`<h2>${i18n('Boxes.InactivesSettings.Toggle')}</h2>`);
@@ -2348,14 +2370,14 @@ let MainParser = {
 				t.push(`<span class="inactivesIgnoreToggle" data-id="${id}" title="${i18n('Boxes.InactivesSettings.NoAlert')}">🤐${MainParser.CityEntities[id].name}</span></br>`);
 			}
 			//t.push(`<h2>${i18n('Boxes.InactivesSettings.ClickToIgnore')}</h2>`);
-			
+
 			for (let id of MainParser.Inactives.list) {
 				t.push(`<span class="inactivesIgnoreToggle" data-id="${id}" title="${i18n('Boxes.InactivesSettings.AlertActive')}">⚠️${MainParser.CityEntities[id].name}</span></br>`);
 			}
-			
-			
+
+
 			$('#inactivesSettingsBoxBody').html(t.join(''));
-			
+
 			$('.inactivesIgnoreToggle').on("click", (e) => {
 				let id = e.target.dataset.id;
 				let i = MainParser.Inactives.ignore.findIndex(x => x==id);

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,7 @@
 	"name": "__MSG_appName__",
 	"description": "__MSG_appDesc__",
 	"default_locale": "en",
-	"version": "4.2.1.0",
-
+	"version": "4.2.2.0",
 	"manifest_version": 3,
 	"permissions": [
 		"alarms",
@@ -12,26 +11,22 @@
 		"notifications",
 		"clipboardWrite"
 	],
-
 	"host_permissions": [
 		"https://*.forgeofempires.com/*",
 		"https://foe-helper.com/*",
 		"https://*.foe-helper.com/*",
 		"https://*.foe-rechner.de/*"
 	],
-
 	"action": {
 		"default_icon": "images/app16.png",
 		"default_popup": "content/popup.html",
 		"default_title": "__MSG_appName__"
 	},
-
 	"icons": {
 		"16": "images/app16.png",
 		"48": "images/app48.png",
 		"128": "images/app128.png"
 	},
-
 	"web_accessible_resources": [
 		{
 			"resources": [
@@ -40,27 +35,44 @@
 				"css/*",
 				"content/*"
 			],
-			"matches": [ "https://*/*" ]
+			"matches": [
+				"https://*/*"
+			]
 		}
 	],
-
 	"content_scripts": [
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
-			"js": ["js/foeproxy.js"],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
+			"js": [
+				"js/foeproxy.js"
+			],
 			"run_at": "document_start",
 			"world": "MAIN"
 		},
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
-			"js": ["js/foeproxy-fallback.js"],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
+			"js": [
+				"js/foeproxy-fallback.js"
+			],
 			"run_at": "document_start"
 		},
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
 			"js": [
 				"vendor/browser-polyfill/browser-polyfill.min.js",
 				"js/web/_languages/js/_languages.js",
@@ -69,12 +81,14 @@
 			"run_at": "document_end"
 		}
 	],
-
-	"externally_connectable" : {
-		"matches": ["https://*.forgeofempires.com/*"],
-		"ids": ["*"]
+	"externally_connectable": {
+		"matches": [
+			"https://*.forgeofempires.com/*"
+		],
+		"ids": [
+			"*"
+		]
 	},
-
 	"background": {
 		"service_worker": "background.js"
 	}

--- a/manifests/chromium/manifest_.json
+++ b/manifests/chromium/manifest_.json
@@ -2,8 +2,7 @@
 	"name": "__MSG_appName__",
 	"description": "__MSG_appDesc__",
 	"default_locale": "en",
-	"version": "4.2.1.0",
-
+	"version": "4.2.2.0",
 	"manifest_version": 3,
 	"permissions": [
 		"alarms",
@@ -12,26 +11,22 @@
 		"notifications",
 		"clipboardWrite"
 	],
-
 	"host_permissions": [
 		"https://*.forgeofempires.com/*",
 		"https://foe-helper.com/*",
 		"https://*.foe-helper.com/*",
 		"https://*.foe-rechner.de/*"
 	],
-
 	"action": {
 		"default_icon": "images/app16.png",
 		"default_popup": "content/popup.html",
 		"default_title": "__MSG_appName__"
 	},
-
 	"icons": {
 		"16": "images/app16.png",
 		"48": "images/app48.png",
 		"128": "images/app128.png"
 	},
-
 	"web_accessible_resources": [
 		{
 			"resources": [
@@ -40,27 +35,44 @@
 				"css/*",
 				"content/*"
 			],
-			"matches": [ "https://*/*" ]
+			"matches": [
+				"https://*/*"
+			]
 		}
 	],
-
 	"content_scripts": [
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
-			"js": ["js/foeproxy.js"],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
+			"js": [
+				"js/foeproxy.js"
+			],
 			"run_at": "document_start",
 			"world": "MAIN"
 		},
 		{
-            "matches": ["https://*.forgeofempires.com/*"],
-            "include_globs": [ "*forgeofempires.com/game*" ],
-            "js": ["js/foeproxy-fallback.js"],
-            "run_at": "document_start"
-        },
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
+			"js": [
+				"js/foeproxy-fallback.js"
+			],
+			"run_at": "document_start"
+		},
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
 			"js": [
 				"vendor/browser-polyfill/browser-polyfill.min.js",
 				"js/web/_languages/js/_languages.js",
@@ -69,12 +81,14 @@
 			"run_at": "document_end"
 		}
 	],
-
-	"externally_connectable" : {
-		"matches": ["https://*.forgeofempires.com/*"],
-		"ids": ["*"]
+	"externally_connectable": {
+		"matches": [
+			"https://*.forgeofempires.com/*"
+		],
+		"ids": [
+			"*"
+		]
 	},
-
 	"background": {
 		"service_worker": "background.js"
 	}

--- a/manifests/firefox/manifest_.json
+++ b/manifests/firefox/manifest_.json
@@ -2,8 +2,7 @@
 	"name": "__MSG_appName__",
 	"description": "__MSG_appDesc__",
 	"default_locale": "en",
-	"version": "4.2.1.0",
-
+	"version": "4.2.2.0",
 	"manifest_version": 2,
 	"permissions": [
 		"alarms",
@@ -16,19 +15,16 @@
 		"https://*.foe-helper.com/*",
 		"https://*.foe-rechner.de/*"
 	],
-
 	"browser_action": {
 		"default_icon": "images/app16.png",
 		"default_popup": "content/popup.html",
 		"default_title": "__MSG_appName__"
 	},
-
 	"icons": {
 		"16": "images/app16.png",
 		"48": "images/app48.png",
 		"128": "images/app128.png"
 	},
-
 	"web_accessible_resources": [
 		"css/web/*.css",
 		"vendor/*.js",
@@ -41,24 +37,39 @@
 		"js/internal.json",
 		"js/foeproxy.js"
 	],
-
 	"content_scripts": [
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
-			"js": ["js/foeproxy.js"],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
+			"js": [
+				"js/foeproxy.js"
+			],
 			"run_at": "document_start",
 			"world": "MAIN"
 		},
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
-			"js": ["js/foeproxy-fallback.js"],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
+			"js": [
+				"js/foeproxy-fallback.js"
+			],
 			"run_at": "document_start"
 		},
 		{
-			"matches": ["https://*.forgeofempires.com/*"],
-			"include_globs": [ "*forgeofempires.com/game*" ],
+			"matches": [
+				"https://*.forgeofempires.com/*"
+			],
+			"include_globs": [
+				"*forgeofempires.com/game*"
+			],
 			"js": [
 				"vendor/browser-polyfill/browser-polyfill.min.js",
 				"js/web/_languages/js/_languages.js",
@@ -67,7 +78,6 @@
 			"run_at": "document_end"
 		}
 	],
-
 	"background": {
 		"scripts": [
 			"vendor/browser-polyfill/browser-polyfill.min.js",


### PR DESCRIPTION
This fixes [GB calculator not opening](https://github.com/mainIine/foe-helfer-extension/issues/3454) issue.

Opening someone else’s great building can return the map entity via `OtherPlayerService.getOtherPlayerCityMapEntity` instead of (or in addition to) `CityMapService.updateEntity`. The extension did not handle that path, and the existing `lgUpdateData` logic could clear pending data between separate game/json responses, so rankings and map entity often never paired. The GB Cost Calculator then stayed empty because `Calculator.CityMapEntity` was never set.